### PR TITLE
Resolve deprecation warnings on test suite by converting should synta…

### DIFF
--- a/plugins/arescentral/specs/char_connected_event_specs.rb
+++ b/plugins/arescentral/specs/char_connected_event_specs.rb
@@ -7,22 +7,22 @@ module AresMUSH
       before do
         @char = double
         @client = double
-        SpecHelpers.setup_mock_client(@client, @char)
-        SpecHelpers.stub_translate_for_testing
+        setup_mock_client(@client, @char)
+        stub_translate_for_testing
         @connector = double
         @handler = CharConnectedEventHandler.new
         
         @char_id = 111
-        Character.stub(:[]).with(@char_id) { @char }
+        allow(Character).to receive(:[]).with(@char_id) { @char }
         
         @event = CharConnectedEvent.new(@client, @char_id)
-        AresCentral::AresConnector.stub(:new) { @connector }
+        allow(AresCentral::AresConnector).to receive(:new) { @connector }
       end
       
       context "no handle" do
         it "should do nothing" do
-          @char.stub(:handle) { nil }
-          @connector.should_not_receive(:sync_handle)
+          allow(@char).to receive(:handle) { nil }
+          expect(@connector).to_not receive(:sync_handle)
           @handler.on_event(@event)
         end
       end
@@ -30,21 +30,21 @@ module AresMUSH
       context "linked" do       
         it "should set the preferences" do
           @handle = double
-          @handle.stub(:handle_id) { 123 }
-          @char.stub(:handle) { @handle }
-          @char.stub(:name) { "Bob" }
-          @char.stub(:id) { 111 }
+          allow(@handle).to receive(:handle_id) { 123 }
+          allow(@char).to receive(:handle) { @handle }
+          allow(@char).to receive(:name) { "Bob" }
+          allow(@char).to receive(:id) { 111 }
           response = { "status" => "success", "data" => { "linked" => true, "autospace" => "x", "timezone" => "t", "friends" => "f", "quote_color" => "q", "page_color" => "pc", "page_autospace" => "ps" }}
           
           
-          @connector.should_receive(:sync_handle).with(123, "Bob", 111) { AresCentral::AresResponse.new(response) }  
-          @char.should_receive(:update).with({:pose_quote_color => "q"})
-          @char.should_receive(:update).with({:pose_autospace => "x"})
-          @char.should_receive(:update).with({:page_autospace => "ps"})
-          @char.should_receive(:update).with({:page_color => "pc"})
-          @char.should_receive(:update).with({:timezone => "t"})
-          @handle.should_receive(:update).with(friends: "f")
-          @client.should_receive(:emit_success).with("arescentral.handle_synced")
+          expect(@connector).to receive(:sync_handle).with(123, "Bob", 111) { AresCentral::AresResponse.new(response) }  
+          expect(@char).to receive(:update).with({:pose_quote_color => "q"})
+          expect(@char).to receive(:update).with({:pose_autospace => "x"})
+          expect(@char).to receive(:update).with({:page_autospace => "ps"})
+          expect(@char).to receive(:update).with({:page_color => "pc"})
+          expect(@char).to receive(:update).with({:timezone => "t"})
+          expect(@handle).to receive(:update).with(friends: "f")
+          expect(@client).to receive(:emit_success).with("arescentral.handle_synced")
           @handler.on_event(@event)
         end
       end
@@ -52,16 +52,16 @@ module AresMUSH
       context "not linked" do
         it "should unlink the handle" do
           @handle = double
-          @handle.stub(:handle_id) { 123 }
-          @char.stub(:handle) { @handle }
-          @char.stub(:name) { "Bob" }
-          @char.stub(:id) { 111 }
+          allow(@handle).to receive(:handle_id) { 123 }
+          allow(@char).to receive(:handle) { @handle }
+          allow(@char).to receive(:name) { "Bob" }
+          allow(@char).to receive(:id) { 111 }
           response = { "status" => "success", "data" => { "linked" => false }}
           
-          @connector.should_receive(:sync_handle).with(123, "Bob", 111) { AresCentral::AresResponse.new(response) }  
-          @char.should_not_receive(:autospace=)
-          @handle.should_receive(:delete)
-          @client.should_receive(:emit_failure).with("arescentral.handle_no_longer_linked")
+          expect(@connector).to receive(:sync_handle).with(123, "Bob", 111) { AresCentral::AresResponse.new(response) }  
+          expect(@char).to_not receive(:autospace=)
+          expect(@handle).to receive(:delete)
+          expect(@client).to receive(:emit_failure).with("arescentral.handle_no_longer_linked")
           @handler.on_event(@event)
         end
       end

--- a/plugins/channels/specs/channel_alias_specs.rb
+++ b/plugins/channels/specs/channel_alias_specs.rb
@@ -6,43 +6,43 @@ module AresMUSH
       before do
         @char = double
         @channel = double
-        Channel.stub(:find_one_by_name).with("Public") { @channel }
+        allow(Channel).to receive(:find_one_by_name).with("Public") { @channel }
       end
       
       context "Alias has a prefix" do
         before do
           @options = double
-          @options.stub(:channel) { @channel }
-          @options.stub(:match_alias).with('pub') { true }
-          @char.stub(:channel_options) { [@options] }
-          Channels.stub(:get_channel_options).with(@char, @channel) { @options }
+          allow(@options).to receive(:channel) { @channel }
+          allow(@options).to receive(:match_alias).with('pub') { true }
+          allow(@char).to receive(:channel_options) { [@options] }
+          allow(Channels).to receive(:get_channel_options).with(@char, @channel) { @options }
         end
 
         it "should match the alias exactly" do
-          Channels.channel_for_alias(@char, "+pub").should eq @channel
+          expect(Channels.channel_for_alias(@char, "+pub")).to eq @channel
         end
       
         it "should match the alias without a prefix" do
-          Channels.channel_for_alias(@char, "pub").should eq @channel
+          expect(Channels.channel_for_alias(@char, "pub")).to eq @channel
         end
 
         it "should match the alias with a different prefix" do
-          Channels.channel_for_alias(@char, "=pub").should eq @channel
+          expect(Channels.channel_for_alias(@char, "=pub")).to eq @channel
         end
       end
       
       context "Alias does not match" do
         before do
           @options = double
-          @options.stub(:channel) { @channel }
-          @options.stub(:match_alias).with('pub') { false }
-          @char.stub(:channel_options) { [@options] }
-          Channels.stub(:get_channel_options).with(@char, @channel) { @options }
+          allow(@options).to receive(:channel) { @channel }
+          allow(@options).to receive(:match_alias).with('pub') { false }
+          allow(@char).to receive(:channel_options) { [@options] }
+          allow(Channels).to receive(:get_channel_options).with(@char, @channel) { @options }
         end
 
         it "should match the alias exactly" do
-          Channel.stub(:all) { [] }
-          Channels.channel_for_alias(@char, "pub").should eq nil
+          allow(Channel).to receive(:all) { [] }
+          expect(Channels.channel_for_alias(@char, "pub")).to eq nil
         end
       end
     end

--- a/plugins/channels/specs/channel_join_cmd_specs.rb
+++ b/plugins/channels/specs/channel_join_cmd_specs.rb
@@ -10,61 +10,61 @@ module AresMUSH
         @char = double
         @client = double
         @options = double
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
         
       describe :join_channel do
         before do
-          Channel.stub(:find_one_by_name).with("pub") { @channel }
-          Channels.stub(:is_on_channel?) { false }
-          Channels.stub(:can_use_channel) { true }
-          Channels.stub(:get_channel_options) { @options }
+          allow(Channel).to receive(:find_one_by_name).with("pub") { @channel }
+          allow(Channels).to receive(:is_on_channel?) { false }
+          allow(Channels).to receive(:can_use_channel) { true }
+          allow(Channels).to receive(:get_channel_options) { @options }
         end
         
         it "should fail if already on channel" do
-          Channels.should_receive(:is_on_channel?).with(@char, @channel) { true }
-          @client.should_receive(:emit_failure).with('channels.already_on_channel')
+          expect(Channels).to receive(:is_on_channel?).with(@char, @channel) { true }
+          expect(@client).to receive(:emit_failure).with('channels.already_on_channel')
           Channels.join_channel("pub", @client, @char, nil)
         end
         
         it "should fail if can't access channel" do
-          Channels.should_receive(:can_use_channel).with(@char, @channel) { false }
-          @client.should_receive(:emit_failure).with('channels.cant_use_channel')
+          expect(Channels).to receive(:can_use_channel).with(@char, @channel) { false }
+          expect(@client).to receive(:emit_failure).with('channels.cant_use_channel')
           Channels.join_channel("pub", @client, @char, nil)
         end
         
         it "should fail if alias already in use" do
-          Channels.should_receive(:set_channel_alias).with(@client, @char, @channel, "pub", false) { false }
-          @client.should_receive(:emit_failure).with('channels.unable_to_determine_auto_alias')
+          expect(Channels).to receive(:set_channel_alias).with(@client, @char, @channel, "pub", false) { false }
+          expect(@client).to receive(:emit_failure).with('channels.unable_to_determine_auto_alias')
           Channels.join_channel("pub", @client, @char, "pub")
         end
         
         context "success" do
           before do
-            Channels.stub(:set_channel_alias) { true }
-            @options.stub(:alias_hint) { "Hint" }
+            allow(Channels).to receive(:set_channel_alias) { true }
+            allow(@options).to receive(:alias_hint) { "Hint" }
             @chars_stub = double
-            @chars_stub.stub(:<<) {}
-            @channel.stub(:characters) { @chars_stub }
-            @channel.stub(:save)
-            Channels.stub(:emit_to_channel) {}
-            @char.stub(:name) { "Bob" }
+            allow(@chars_stub).to receive(:<<) {}
+            allow(@channel).to receive(:characters) { @chars_stub }
+            allow(@channel).to receive(:save)
+            allow(Channels).to receive(:emit_to_channel) {}
+            allow(@char).to receive(:name) { "Bob" }
           end
           
           it "should use default alias if none specified" do
-            @channel.stub(:default_alias) { [ "pub" ]}
-            Channels.should_receive(:set_channel_alias).with(@client, @char, @channel, "pub", false) { true }
+            allow(@channel).to receive(:default_alias) { [ "pub" ]}
+            expect(Channels).to receive(:set_channel_alias).with(@client, @char, @channel, "pub", false) { true }
             Channels.join_channel("pub", @client, @char, nil)
           end
         
           it "should use alias if specified" do
-            @channel.stub(:default_alias) { [ "pub" ]}
-            Channels.should_receive(:set_channel_alias).with(@client, @char, @channel, "p2", false) { true }
+            allow(@channel).to receive(:default_alias) { [ "pub" ]}
+            expect(Channels).to receive(:set_channel_alias).with(@client, @char, @channel, "p2", false) { true }
             Channels.join_channel("pub", @client, @char, "p2")
           end
         
           it "should add the char to the channel" do
-            @chars_stub.should_receive(:<<).with(@char) {}
+            expect(@chars_stub).to receive(:<<).with(@char) {}
             Channels.join_channel("pub", @client, @char, "p")
           end
         end

--- a/plugins/describe/specs/shared_specs.rb
+++ b/plugins/describe/specs/shared_specs.rb
@@ -10,7 +10,7 @@ module AresMUSH
         
         context "describing self" do
           it "should always let you describe yourself" do
-            Describe.can_describe?(@char, @char).should be true
+            expect(Describe.can_describe?(@char, @char)).to be true
           end
         end
         
@@ -20,13 +20,13 @@ module AresMUSH
           end
           
           it "should let someone with desc-anything power describe any object" do
-            @char.stub(:has_permission?).with("desc_anything") { true }
-            Describe.can_describe?(@char, @target).should be true
+            allow(@char).to receive(:has_permission?).with("desc_anything") { true }
+            expect(Describe.can_describe?(@char, @target)).to be true
           end
 
           it "should not let random people describe any object" do
-            @char.stub(:has_permission?).with("desc_anything") { false }
-            Describe.can_describe?(@char, @target).should be false
+            allow(@char).to receive(:has_permission?).with("desc_anything") { false }
+            expect(Describe.can_describe?(@char, @target)).to be false
           end
         end
         
@@ -36,31 +36,31 @@ module AresMUSH
           end
           
           it "should allow a builder to describe a room" do
-            @char.stub(:has_permission?).with("desc_anything") { false }
-            @char.stub(:has_permission?).with("desc_places") { true }
-            @room.stub(:owned_by?).with(@char) { false }
-            Describe.can_describe?(@char, @room).should be true
+            allow(@char).to receive(:has_permission?).with("desc_anything") { false }
+            allow(@char).to receive(:has_permission?).with("desc_places") { true }
+            allow(@room).to receive(:owned_by?).with(@char) { false }
+            expect(Describe.can_describe?(@char, @room)).to be true
           end
           
           it "should allow someone with desc-anything power to describe a room" do
-            @char.stub(:has_permission?).with("desc_anything") { true }
-            @char.stub(:has_permission?).with("desc_places") { false }
-            @room.stub(:owned_by?).with(@char) { false }
-            Describe.can_describe?(@char, @room).should be true
+            allow(@char).to receive(:has_permission?).with("desc_anything") { true }
+            allow(@char).to receive(:has_permission?).with("desc_places") { false }
+            allow(@room).to receive(:owned_by?).with(@char) { false }
+            expect(Describe.can_describe?(@char, @room)).to be true
           end
           
           it "should allow a room owner to describe a room" do
-            @char.stub(:has_permission?).with("desc_anything") { false }
-            @char.stub(:has_permission?).with("desc_places") { false }
-            @room.stub(:owned_by?).with(@char) { true }
-            Describe.can_describe?(@char, @room).should be true
+            allow(@char).to receive(:has_permission?).with("desc_anything") { false }
+            allow(@char).to receive(:has_permission?).with("desc_places") { false }
+            allow(@room).to receive(:owned_by?).with(@char) { true }
+            expect(Describe.can_describe?(@char, @room)).to be true
           end
           
           it "should not allow someone without permission to describe a room" do
-            @char.stub(:has_permission?).with("desc_anything") { false }
-            @char.stub(:has_permission?).with("desc_places") { false }
-            @room.stub(:owned_by?).with(@char) { false }
-            Describe.can_describe?(@char, @room).should be false
+            allow(@char).to receive(:has_permission?).with("desc_anything") { false }
+            allow(@char).to receive(:has_permission?).with("desc_places") { false }
+            allow(@room).to receive(:owned_by?).with(@char) { false }
+            expect(Describe.can_describe?(@char, @room)).to be false
           end
         end
       end

--- a/plugins/forum/specs/bbs_post_cmd_specs.rb
+++ b/plugins/forum/specs/bbs_post_cmd_specs.rb
@@ -6,9 +6,9 @@ module AresMUSH
     describe ForumPostCmd do
       before do
         @category = double
-        BbsBoard.stub(:find_one_by_name).with("announce") { @category }
+        allow(BbsBoard).to receive(:find_one_by_name).with("announce") { @category }
 
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
       
       
@@ -17,34 +17,34 @@ module AresMUSH
         it "should ignore a missing arg" do
           handler = ForumPostCmd.new(nil, Command.new("forum/post category=subj"), nil)
           handler.parse_args
-          handler.category_name.should be_nil
-          handler.subject.should be_nil
-          handler.message.should be_nil
+          expect(handler.category_name).to be_nil
+          expect(handler.subject).to be_nil
+          expect(handler.message).to be_nil
         end
         
         context "Myrddin syntax" do
           it "should handle the Myrddin syntax" do
             handler = ForumPostCmd.new(nil, Command.new("forum/post category/subj=msg"), nil)
             handler.parse_args
-            handler.category_name.should eq "category"
-            handler.subject.should eq "subj"
-            handler.message.should eq "msg"
+            expect(handler.category_name).to eq "category"
+            expect(handler.subject).to eq "subj"
+            expect(handler.message).to eq "msg"
           end
 
           it "should stop the subject after the first slash" do
             handler = ForumPostCmd.new(nil, Command.new("forum/post category/subj=msg with a / slash"), nil)
             handler.parse_args
-            handler.category_name.should eq "category"
-            handler.subject.should eq "subj"
-            handler.message.should eq "msg with a / slash"
+            expect(handler.category_name).to eq "category"
+            expect(handler.subject).to eq "subj"
+            expect(handler.message).to eq "msg with a / slash"
           end
         
           it "should stop the subjecta fter the first equals" do
             handler = ForumPostCmd.new(nil, Command.new("forum/post category/subj=msg with a = equals"), nil)
             handler.parse_args
-            handler.category_name.should eq "category"
-            handler.subject.should eq "subj"
-            handler.message.should eq "msg with a = equals"
+            expect(handler.category_name).to eq "category"
+            expect(handler.subject).to eq "subj"
+            expect(handler.message).to eq "msg with a = equals"
           end
         end
       
@@ -52,25 +52,25 @@ module AresMUSH
           it "should handle the Fara syntax" do
             handler = ForumPostCmd.new(nil, Command.new("forum/post category=subj/msg"), nil)
             handler.parse_args
-            handler.category_name.should eq "category"
-            handler.subject.should eq "subj"
-            handler.message.should eq "msg"
+            expect(handler.category_name).to eq "category"
+            expect(handler.subject).to eq "subj"
+            expect(handler.message).to eq "msg"
           end
         
           it "should stop the subject after the first slash" do
             handler = ForumPostCmd.new(nil, Command.new("forum/post category=subj/msg with a / slash"), nil)
             handler.parse_args
-            handler.category_name.should eq "category"
-            handler.subject.should eq "subj"
-            handler.message.should eq "msg with a / slash"
+            expect(handler.category_name).to eq "category"
+            expect(handler.subject).to eq "subj"
+            expect(handler.message).to eq "msg with a / slash"
           end
         
           it "should stop the subject after the first equals" do
             handler = ForumPostCmd.new(nil, Command.new("forum/post category=subj/msg with a = equals"), nil)
             handler.parse_args
-            handler.category_name.should eq "category"
-            handler.subject.should eq "subj"
-            handler.message.should eq "msg with a = equals"
+            expect(handler.category_name).to eq "category"
+            expect(handler.subject).to eq "subj"
+            expect(handler.message).to eq "msg with a = equals"
           end
         end
       end

--- a/plugins/friends/specs/model_specs.rb
+++ b/plugins/friends/specs/model_specs.rb
@@ -8,17 +8,17 @@ module AresMUSH
           before do
             @char = Character.new(name: "Bob")
             @other = Character.new(name: "Harry")
-            @char.stub(:friends) { [] }
-            @other.stub(:friends) { [] }
+            allow(@char).to receive(:friends) { [] }
+            allow(@other).to receive(:friends) { [] }
           end
         
           it "should return true if on character friends list" do
-            @char.stub(:friends) { [ @other ] }
-            @char.has_friended_char_or_handle?(@other).should be true
+            allow(@char).to receive(:friends) { [ @other ] }
+            expect(@char.has_friended_char_or_handle?(@other)).to be true
           end
         
           it "should return false if not a friend" do
-            @char.has_friended_char_or_handle?(@other).should be false
+            expect(@char.has_friended_char_or_handle?(@other)).to be false
           end
         end
         
@@ -27,35 +27,35 @@ module AresMUSH
           before do
             @char = Character.new(name: "Bob")
             @other = Character.new(name: "Harry")
-            @char.stub(:friends) { [] }
-            @other.stub(:friends) { [] }
+            allow(@char).to receive(:friends) { [] }
+            allow(@other).to receive(:friends) { [] }
             @handle = Handle.new(name: "BobHandle")
             @other_handle = Handle.new(name: "HarryHandle")
           end
           
           it "should return true if on handle friends list" do
-            @char.stub(:handle) { @handle }
-            @handle.stub(:friends) { [ "HarryHandle" ] }
-            @other.stub(:handle) { @other_handle }
+            allow(@char).to receive(:handle) { @handle }
+            allow(@handle).to receive(:friends) { [ "HarryHandle" ] }
+            allow(@other).to receive(:handle) { @other_handle }
             
-            @char.has_friended_char_or_handle?(@other).should be true
+            expect(@char.has_friended_char_or_handle?(@other)).to be true
           end
         
           it "should return false if this char has no handle" do
-            @other.stub(:handle) { @other_handle }
-            @char.has_friended_char_or_handle?(@other).should be false          
+            allow(@other).to receive(:handle) { @other_handle }
+            expect(@char.has_friended_char_or_handle?(@other)).to be false          
           end
         
           it "should return false if other char has no handle" do
-            @char.stub(:handle) { @handle }
-            @handle.stub(:friends) { [ "HarryHandle" ] }
-            @char.has_friended_char_or_handle?(@other).should be false          
+            allow(@char).to receive(:handle) { @handle }
+            allow(@handle).to receive(:friends) { [ "HarryHandle" ] }
+            expect(@char.has_friended_char_or_handle?(@other)).to be false          
           end
           
           it "should return false if this char has no friends" do
-            @char.stub(:handle) { @handle }
-            @other.stub(:handle) { @other_handle }
-            @char.has_friended_char_or_handle?(@other).should be false          
+            allow(@char).to receive(:handle) { @handle }
+            allow(@other).to receive(:handle) { @other_handle }
+            expect(@char.has_friended_char_or_handle?(@other)).to be false          
           end
           
           

--- a/plugins/fs3combat/specs/action_helper_specs.rb
+++ b/plugins/fs3combat/specs/action_helper_specs.rb
@@ -2,84 +2,84 @@ module AresMUSH
   module FS3Combat
     describe FS3Combat do
       before do
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
       
       describe :reset_for_new_turn do
         before do 
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:name) { "Trooper" }
-          @combatant.stub(:update)
-          @combatant.stub(:is_aiming?) { false }
-          @combatant.stub(:is_subdued?) { false }
-          @combatant.stub(:freshly_damaged) { false }
-          @combatant.stub(:action_klass) { nil }
-          @combatant.stub(:is_ko) { false }
-          @combatant.stub(:luck) { "Defense" }
-          FS3Combat.stub(:reset_stress)
-          FS3Combat.stub(:check_for_ko)
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:name) { "Trooper" }
+          allow(@combatant).to receive(:update)
+          allow(@combatant).to receive(:is_aiming?) { false }
+          allow(@combatant).to receive(:is_subdued?) { false }
+          allow(@combatant).to receive(:freshly_damaged) { false }
+          allow(@combatant).to receive(:action_klass) { nil }
+          allow(@combatant).to receive(:is_ko) { false }
+          allow(@combatant).to receive(:luck) { "Defense" }
+          allow(FS3Combat).to receive(:reset_stress)
+          allow(FS3Combat).to receive(:check_for_ko)
         end
         
         it "should reset luck spent" do
-          @combatant.should_receive(:update).with(luck: nil)
+          expect(@combatant).to receive(:update).with(luck: nil)
           FS3Combat.reset_for_new_turn(@combatant)
         end
         
         it "should reset posed" do
-          @combatant.should_receive(:update).with(posed: false)
+          expect(@combatant).to receive(:update).with(posed: false)
           FS3Combat.reset_for_new_turn(@combatant)
         end
         
         it "should reset recoil" do
-          @combatant.should_receive(:update).with(recoil: 0)
+          expect(@combatant).to receive(:update).with(recoil: 0)
           FS3Combat.reset_for_new_turn(@combatant)
         end
         
         it "should reset fresh damage" do
-          @combatant.should_receive(:update).with(freshly_damaged: false)
+          expect(@combatant).to receive(:update).with(freshly_damaged: false)
           FS3Combat.reset_for_new_turn(@combatant)
         end
         
         it "should reset aiming if they aren't still aiming" do 
-          @combatant.stub(:is_aiming?) { true }
-          @combatant.stub(:action) { AttackAction.new(@combatant, "") }
-          @combatant.should_receive(:update).with(aim_target: nil)
+          allow(@combatant).to receive(:is_aiming?) { true }
+          allow(@combatant).to receive(:action) { AttackAction.new(@combatant, "") }
+          expect(@combatant).to receive(:update).with(aim_target: nil)
           FS3Combat.reset_for_new_turn(@combatant)
         end
 
         it "should not reset aiming if they're still aiming" do 
-          @combatant.stub(:is_aiming?) { true }
-          @combatant.stub(:action_klass) { "AresMUSH::FS3Combat::AimAction" }
-          @combatant.should_not_receive(:update).with(aim_target: nil)
+          allow(@combatant).to receive(:is_aiming?) { true }
+          allow(@combatant).to receive(:action_klass) { "AresMUSH::FS3Combat::AimAction" }
+          expect(@combatant).to_not receive(:update).with(aim_target: nil)
           FS3Combat.reset_for_new_turn(@combatant)
         end
         
         it "should reset subdued if their attacker is no longer subduing them" do
           subduer = double
-          @combatant.stub(:is_subdued?) { false }
-          @combatant.should_receive(:update).with(subdued_by: nil)
+          allow(@combatant).to receive(:is_subdued?) { false }
+          expect(@combatant).to receive(:update).with(subdued_by: nil)
           FS3Combat.reset_for_new_turn(@combatant)
         end
 
         it "should not reset subdued if their attacker is still subduing them" do
           subduer = double
-          @combatant.stub(:is_subdued?) { true }
-          @combatant.should_not_receive(:update).with(subdued_by: nil)
+          allow(@combatant).to receive(:is_subdued?) { true }
+          expect(@combatant).to_not receive(:update).with(subdued_by: nil)
           FS3Combat.reset_for_new_turn(@combatant)
         end
         
         it "should lower stress" do
-          FS3Combat.should_receive(:reset_stress).with(@combatant)
+          expect(FS3Combat).to receive(:reset_stress).with(@combatant)
           FS3Combat.reset_for_new_turn(@combatant)
         end
         
         it "should remove a KO'ed NPC" do
-          @combatant.stub(:is_ko) { true }
-          @combatant.stub(:is_npc?) { true }
+          allow(@combatant).to receive(:is_ko) { true }
+          allow(@combatant).to receive(:is_npc?) { true }
           combat = double
-          @combatant.stub(:combat) { combat }
-          FS3Combat.should_receive(:leave_combat).with(combat, @combatant)
+          allow(@combatant).to receive(:combat) { combat }
+          expect(FS3Combat).to receive(:leave_combat).with(combat, @combatant)
           FS3Combat.reset_for_new_turn(@combatant)
         end
       end
@@ -87,37 +87,37 @@ module AresMUSH
       describe :reset_stress do 
         before do
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:name) { "Bob" }
-          @combatant.stub(:stress) { 0 }
-          @combatant.stub(:distraction) { 0 }
-          Global.stub(:read_config).with("fs3combat", "composure_skill") { "Composure" }
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:name) { "Bob" }
+          allow(@combatant).to receive(:stress) { 0 }
+          allow(@combatant).to receive(:distraction) { 0 }
+          allow(Global).to receive(:read_config).with("fs3combat", "composure_skill") { "Composure" }
         end
         
         it "should reduce stress by 1 even if roll fails" do
-          @combatant.stub(:stress) { 3 }
-          @combatant.stub(:distraction) { 2 }
-          @combatant.stub(:roll_ability).with("Composure") { 0 }
-          @combatant.should_receive(:update).with(stress: 2)
-          @combatant.should_receive(:update).with(distraction: 1)
+          allow(@combatant).to receive(:stress) { 3 }
+          allow(@combatant).to receive(:distraction) { 2 }
+          allow(@combatant).to receive(:roll_ability).with("Composure") { 0 }
+          expect(@combatant).to receive(:update).with(stress: 2)
+          expect(@combatant).to receive(:update).with(distraction: 1)
           FS3Combat.reset_stress(@combatant)
         end
         
         it "should reduce stress by roll result further" do
-          @combatant.stub(:stress) { 3 }
-          @combatant.stub(:distraction) { 4 }
-          @combatant.stub(:roll_ability).with("Composure") { 2 }
-          @combatant.should_receive(:update).with(stress: 0)
-          @combatant.should_receive(:update).with(distraction: 1)
+          allow(@combatant).to receive(:stress) { 3 }
+          allow(@combatant).to receive(:distraction) { 4 }
+          allow(@combatant).to receive(:roll_ability).with("Composure") { 2 }
+          expect(@combatant).to receive(:update).with(stress: 0)
+          expect(@combatant).to receive(:update).with(distraction: 1)
           FS3Combat.reset_stress(@combatant)
         end
         
         it "should not reduce stress below 0" do
-          @combatant.stub(:stress) { 1 }
-          @combatant.stub(:distraction) { 1 }
-          @combatant.stub(:roll_ability).with("Composure") { 2 }
-          @combatant.should_receive(:update).with(stress: 0)
-          @combatant.should_receive(:update).with(distraction: 0)
+          allow(@combatant).to receive(:stress) { 1 }
+          allow(@combatant).to receive(:distraction) { 1 }
+          allow(@combatant).to receive(:roll_ability).with("Composure") { 2 }
+          expect(@combatant).to receive(:update).with(stress: 0)
+          expect(@combatant).to receive(:update).with(distraction: 0)
           FS3Combat.reset_stress(@combatant)
         end
       end
@@ -125,65 +125,65 @@ module AresMUSH
       describe :check_for_ko do
         before do
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:name) { "Bob" }
-          @combatant.stub(:is_ko) { false }
-          @combatant.stub(:freshly_damaged) { true }
-          @combatant.stub(:total_damage_mod) { -2.0 }
-          @combatant.stub(:is_npc?) { false }
-          @combatant.stub(:name) { "Bob" }
-          @combatant.stub(:damaged_by) { [ "Bob" ] }
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:name) { "Bob" }
+          allow(@combatant).to receive(:is_ko) { false }
+          allow(@combatant).to receive(:freshly_damaged) { true }
+          allow(@combatant).to receive(:total_damage_mod) { -2.0 }
+          allow(@combatant).to receive(:is_npc?) { false }
+          allow(@combatant).to receive(:name) { "Bob" }
+          allow(@combatant).to receive(:damaged_by) { [ "Bob" ] }
         end
         
         it "should do nothing if already KOd" do
-          @combatant.stub(:is_ko) { true }
+          allow(@combatant).to receive(:is_ko) { true }
           FS3Combat.check_for_ko(@combatant)
         end
         
         it "should do nothing if only slightly injured" do
-          @combatant.stub(:total_damage_mod) { -0.99 }
+          allow(@combatant).to receive(:total_damage_mod) { -0.99 }
           FS3Combat.check_for_ko(@combatant)
         end
         
         it "should do nothing if not freshly damaged" do
-          @combatant.stub(:freshly_damaged) { false }
+          allow(@combatant).to receive(:freshly_damaged) { false }
           FS3Combat.check_for_ko(@combatant)
         end
         
         it "should KO the person if roll fails" do
           combat = double
-          FS3Combat.should_receive(:make_ko_roll).with(@combatant) { 0 }
-          @combatant.should_receive(:update).with(action_klass: nil)
-          @combatant.should_receive(:update).with(action_args: nil)
-          @combatant.should_receive(:update).with(is_ko: true)
-          @combatant.stub(:combat) { combat }
-          FS3Combat.should_receive(:emit_to_combat).with(combat, "fs3combat.is_koed", nil, true)
+          expect(FS3Combat).to receive(:make_ko_roll).with(@combatant) { 0 }
+          expect(@combatant).to receive(:update).with(action_klass: nil)
+          expect(@combatant).to receive(:update).with(action_args: nil)
+          expect(@combatant).to receive(:update).with(is_ko: true)
+          allow(@combatant).to receive(:combat) { combat }
+          expect(FS3Combat).to receive(:emit_to_combat).with(combat, "fs3combat.is_koed", nil, true)
           FS3Combat.check_for_ko(@combatant)
         end
         
         it "should auto-ko a NPC with enough damage" do
           combat = double
-          @combatant.stub(:total_damage_mod) { -7.1 }
-          @combatant.stub(:is_npc?) { true }
-          FS3Combat.should_not_receive(:make_ko_roll)
-          @combatant.should_receive(:update).with(action_klass: nil)
-          @combatant.should_receive(:update).with(action_args: nil)
-          @combatant.should_receive(:update).with(is_ko: true)
-          @combatant.stub(:combat) { combat }
-          FS3Combat.should_receive(:emit_to_combat).with(combat, "fs3combat.is_koed", nil, true)
+          allow(@combatant).to receive(:total_damage_mod) { -7.1 }
+          allow(@combatant).to receive(:is_npc?) { true }
+          expect(FS3Combat).to_not receive(:make_ko_roll)
+          expect(@combatant).to receive(:update).with(action_klass: nil)
+          expect(@combatant).to receive(:update).with(action_args: nil)
+          expect(@combatant).to receive(:update).with(is_ko: true)
+          allow(@combatant).to receive(:combat) { combat }
+          expect(FS3Combat).to receive(:emit_to_combat).with(combat, "fs3combat.is_koed", nil, true)
           FS3Combat.check_for_ko(@combatant)
         end
         
         it "should not auto-ko a PC with enough damage" do
           combat = double
-          @combatant.stub(:total_damage_mod) { -10.1 }
-          @combatant.stub(:is_npc?) { false }
-          FS3Combat.should_receive(:make_ko_roll).with(@combatant) { 1 }
+          allow(@combatant).to receive(:total_damage_mod) { -10.1 }
+          allow(@combatant).to receive(:is_npc?) { false }
+          expect(FS3Combat).to receive(:make_ko_roll).with(@combatant) { 1 }
           FS3Combat.check_for_ko(@combatant)
         end
         
         it "should not KO the person if their roll succeeds" do
-          FS3Combat.should_receive(:make_ko_roll).with(@combatant) { 1 }
+          expect(FS3Combat).to receive(:make_ko_roll).with(@combatant) { 1 }
           FS3Combat.check_for_ko(@combatant)
         end
       end
@@ -191,27 +191,27 @@ module AresMUSH
       describe :check_for_unko do
         before do
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:is_ko) { true }
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:is_ko) { true }
         end
         
         it "should do nothing if not KOd" do
-          @combatant.stub(:is_ko) { false }
+          allow(@combatant).to receive(:is_ko) { false }
           FS3Combat.check_for_unko(@combatant)
         end
         
         it "should do nothing if KO roll fails" do
-          FS3Combat.should_receive(:make_ko_roll).with(@combatant, 3) { 0 }
+          expect(FS3Combat).to receive(:make_ko_roll).with(@combatant, 3) { 0 }
           FS3Combat.check_for_unko(@combatant)
         end
         
         it "should un-KO the person if their roll succeeds" do
           combat = double
-          @combatant.stub(:name) { "Bob" }
-          @combatant.should_receive(:update).with(is_ko: false)
-          FS3Combat.should_receive(:make_ko_roll).with(@combatant, 3) { 1 }
-          @combatant.stub(:combat) { combat }
-          FS3Combat.should_receive(:emit_to_combat).with(combat, "fs3combat.is_no_longer_koed", nil, true) {}
+          allow(@combatant).to receive(:name) { "Bob" }
+          expect(@combatant).to receive(:update).with(is_ko: false)
+          expect(FS3Combat).to receive(:make_ko_roll).with(@combatant, 3) { 1 }
+          allow(@combatant).to receive(:combat) { combat }
+          expect(FS3Combat).to receive(:emit_to_combat).with(combat, "fs3combat.is_no_longer_koed", nil, true) {}
           FS3Combat.check_for_unko(@combatant)
         end
       end
@@ -219,60 +219,60 @@ module AresMUSH
       describe :make_ko_roll do
         before do
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:name) { "Bob" }
-          @combatant.stub(:total_damage_mod) { -2 }
-          @combatant.stub(:is_npc?) { true }
-          Global.stub(:read_config).with("fs3combat", "pc_knockout_bonus") { 3 }
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:name) { "Bob" }
+          allow(@combatant).to receive(:total_damage_mod) { -2 }
+          allow(@combatant).to receive(:is_npc?) { true }
+          allow(Global).to receive(:read_config).with("fs3combat", "pc_knockout_bonus") { 3 }
         end
         
         it "should roll vehicle toughness if in a vehicle" do
           vehicle = double
-          Global.stub(:read_config).with("fs3combat", "composure_skill") { "Composure" }
-          vehicle.stub(:vehicle_type) { "Viper" }
-          @combatant.stub(:is_in_vehicle?) { true }
-          @combatant.stub(:vehicle) { vehicle }
-          FS3Combat.stub(:vehicle_stat).with("Viper", "toughness") { 5 }
+          allow(Global).to receive(:read_config).with("fs3combat", "composure_skill") { "Composure" }
+          allow(vehicle).to receive(:vehicle_type) { "Viper" }
+          allow(@combatant).to receive(:is_in_vehicle?) { true }
+          allow(@combatant).to receive(:vehicle) { vehicle }
+          allow(FS3Combat).to receive(:vehicle_stat).with("Viper", "toughness") { 5 }
           # Total mod = +5 for vehicle, -4 for damage (-2 x 2)
-          @combatant.should_receive(:roll_ability).with("Composure", 1) { 1 }
-          FS3Combat.make_ko_roll(@combatant).should eq 1
+          expect(@combatant).to receive(:roll_ability).with("Composure", 1) { 1 }
+          expect(FS3Combat.make_ko_roll(@combatant)).to eq 1
         end
         
         it "should roll personal toughness if not in a vehicle" do
-          @combatant.stub(:is_in_vehicle?) { false }
-          Global.stub(:read_config).with("fs3combat", "composure_skill") { "Composure" }
-          @combatant.should_receive(:roll_ability).with("Composure", -4) { 1 }
-          FS3Combat.make_ko_roll(@combatant).should eq 1
+          allow(@combatant).to receive(:is_in_vehicle?) { false }
+          allow(Global).to receive(:read_config).with("fs3combat", "composure_skill") { "Composure" }
+          expect(@combatant).to receive(:roll_ability).with("Composure", -4) { 1 }
+          expect(FS3Combat.make_ko_roll(@combatant)).to eq 1
         end
         
         it "should give PCs a bonus to knockout" do
-          @combatant.stub(:is_npc?) { false }
-          @combatant.stub(:is_in_vehicle?) { false }
-          Global.stub(:read_config).with("fs3combat", "composure_skill") { "Composure" }
-          @combatant.should_receive(:roll_ability).with("Composure", -1) { 1 }
-          FS3Combat.make_ko_roll(@combatant).should eq 1
+          allow(@combatant).to receive(:is_npc?) { false }
+          allow(@combatant).to receive(:is_in_vehicle?) { false }
+          allow(Global).to receive(:read_config).with("fs3combat", "composure_skill") { "Composure" }
+          expect(@combatant).to receive(:roll_ability).with("Composure", -1) { 1 }
+          expect(FS3Combat.make_ko_roll(@combatant)).to eq 1
         end
       end
       
       describe :ai_action do
         before do
           @combatant = double
-          @combatant.stub(:log)
+          allow(@combatant).to receive(:log)
           @client = double
           @combat = double
-          FS3Combat.stub(:check_ammo) { true }
-          @combatant.stub(:is_subdued?) { false }
+          allow(FS3Combat).to receive(:check_ammo) { true }
+          allow(@combatant).to receive(:is_subdued?) { false }
         end
         
         it "should choose reload if out of ammo" do
-          FS3Combat.should_receive(:check_ammo).with(@combatant, 1) { false }
-          FS3Combat.should_receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::ReloadAction, "")
+          expect(FS3Combat).to receive(:check_ammo).with(@combatant, 1) { false }
+          expect(FS3Combat).to receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::ReloadAction, "")
           FS3Combat.ai_action(@combat, @client, @combatant)
         end
         
         it "should choose escape if subdued" do
-          @combatant.stub(:is_subdued?) { true }
-          FS3Combat.should_receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::EscapeAction, "")
+          allow(@combatant).to receive(:is_subdued?) { true }
+          expect(FS3Combat).to receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::EscapeAction, "")
           FS3Combat.ai_action(@combat, @client, @combatant)
         end
 
@@ -280,37 +280,37 @@ module AresMUSH
           before do
             @target1 = double
             @target2 = double
-            @target2.stub(:name) { "Bob" }
-            @combatant.stub(:team) { 1 }
-            @combatant.stub(:weapon) { "Rifle" }
-            @target1.stub(:team) { 1 }
-            @target2.stub(:team) { 2 }
-            FS3Combat.stub(:weapon_stat) { "" }
-            FS3Combat.stub(:find_ai_target) { @target2 }
+            allow(@target2).to receive(:name) { "Bob" }
+            allow(@combatant).to receive(:team) { 1 }
+            allow(@combatant).to receive(:weapon) { "Rifle" }
+            allow(@target1).to receive(:team) { 1 }
+            allow(@target2).to receive(:team) { 2 }
+            allow(FS3Combat).to receive(:weapon_stat) { "" }
+            allow(FS3Combat).to receive(:find_ai_target) { @target2 }
           end   
                    
           it "should attack a random target" do
-            FS3Combat.should_receive(:find_ai_target).with(@combat, @combatant) { @target2 }
-            FS3Combat.should_receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::AttackAction, "Bob")
+            expect(FS3Combat).to receive(:find_ai_target).with(@combat, @combatant) { @target2 }
+            expect(FS3Combat).to receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::AttackAction, "Bob")
             FS3Combat.ai_action(@combat, @client, @combatant)
           end
           
           it "should do nothing if no valid target found" do
-            FS3Combat.should_receive(:find_ai_target).with(@combat, @combatant) { nil }
-            FS3Combat.should_receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::PassAction, "")
+            expect(FS3Combat).to receive(:find_ai_target).with(@combat, @combatant) { nil }
+            expect(FS3Combat).to receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::PassAction, "")
             FS3Combat.ai_action(@combat, @client, @combatant)
           end
           
           it "should use the explode action for explosive weapons" do
-            FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }            
-            FS3Combat.should_receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::ExplodeAction, "Bob")
+            expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }            
+            expect(FS3Combat).to receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::ExplodeAction, "Bob")
 
             FS3Combat.ai_action(@combat, @client, @combatant)
           end
           
           it "should use the suppress action for suppressive weapons" do
-            FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Suppressive" }            
-            FS3Combat.should_receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::SuppressAction, "Bob")
+            expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Suppressive" }            
+            expect(FS3Combat).to receive(:set_action).with(@client, nil, @combat, @combatant, FS3Combat::SuppressAction, "Bob")
 
             FS3Combat.ai_action(@combat, @client, @combatant)
           end
@@ -325,85 +325,85 @@ module AresMUSH
           @target1 = double("t1")
           @target2 = double("t2")
           @target3 = double("t3")
-          @target1.stub(:stance) { "Normal" }
-          @target2.stub(:stance) { "Normal" }
-          @target3.stub(:stance) { "Normal" }
-          @attacker.stub(:team) { 1 }
-          @combat.stub(:active_combatants) { [@attacker, @target1, @target2, @target3] }
-          Array.any_instance.stub(:shuffle) do |instance|
+          allow(@target1).to receive(:stance) { "Normal" }
+          allow(@target2).to receive(:stance) { "Normal" }
+          allow(@target3).to receive(:stance) { "Normal" }
+          allow(@attacker).to receive(:team) { 1 }
+          allow(@combat).to receive(:active_combatants) { [@attacker, @target1, @target2, @target3] }
+          allow_any_instance_of(Array).to receive(:shuffle) do |instance|
             instance
           end
         end
         
         it "should find a random target on any other team if no team target specified" do
-          @combat.stub(:team_targets) { {} }
-          @target1.stub(:team) { 1 }
-          @target2.stub(:team) { 2 }
-          @target3.stub(:team) { 3 }
+          allow(@combat).to receive(:team_targets) { {} }
+          allow(@target1).to receive(:team) { 1 }
+          allow(@target2).to receive(:team) { 2 }
+          allow(@target3).to receive(:team) { 3 }
 
           target = FS3Combat.find_ai_target(@combat, @attacker)
-          target.should eq @target2
+          expect(target).to eq @target2
         end
         
         it "should omit targets that are hidden " do
-          @combat.stub(:team_targets) { {} }
-          @target1.stub(:team) { 1 }
-          @target2.stub(:team) { 2 }
-          @target3.stub(:team) { 3 }
-          @target2.stub(:stance) { "Hidden" }
+          allow(@combat).to receive(:team_targets) { {} }
+          allow(@target1).to receive(:team) { 1 }
+          allow(@target2).to receive(:team) { 2 }
+          allow(@target3).to receive(:team) { 3 }
+          allow(@target2).to receive(:stance) { "Hidden" }
 
           target = FS3Combat.find_ai_target(@combat, @attacker)
-          target.should eq @target3
+          expect(target).to eq @target3
         end
         
         it "should find a random target on the specified team target teams" do
-          @combat.stub(:team_targets) { { "1" => [ 3, 4 ] } }
-          @target1.stub(:team) { 1 }
-          @target2.stub(:team) { 2 }
-          @target3.stub(:team) { 3 }
+          allow(@combat).to receive(:team_targets) { { "1" => [ 3, 4 ] } }
+          allow(@target1).to receive(:team) { 1 }
+          allow(@target2).to receive(:team) { 2 }
+          allow(@target3).to receive(:team) { 3 }
 
           target = FS3Combat.find_ai_target(@combat, @attacker)
-          target.should eq @target3
+          expect(target).to eq @target3
         end
         
         it "should return nil if no valid targets found" do
-          @combat.stub(:team_targets) { { "1" => [ 4 ] } }
+          allow(@combat).to receive(:team_targets) { { "1" => [ 4 ] } }
           
-          @target1.stub(:team) { 1 }
-          @target2.stub(:team) { 2 }
-          @target3.stub(:team) { 3 }
+          allow(@target1).to receive(:team) { 1 }
+          allow(@target2).to receive(:team) { 2 }
+          allow(@target3).to receive(:team) { 3 }
 
           target = FS3Combat.find_ai_target(@combat, @attacker)
-          target.should eq nil
+          expect(target).to eq nil
         end
       end
       
       describe :stopped_by_cover? do
         before do 
           @combatant = double
-          @combatant.stub(:log)
+          allow(@combatant).to receive(:log)
         end
         
         it "should bypass cover if enough successes on attack roll" do
-          FS3Combat.stub(:rand) { 0 }
-          FS3Combat.stopped_by_cover?(3, @combatant).should be false
+          allow(FS3Combat).to receive(:rand) { 0 }
+          expect(FS3Combat.stopped_by_cover?(3, @combatant)).to be false
         end
         
         it "should have 50% cover for a marginal attack roll" do
-          FS3Combat.stub(:rand) { 51 }
-          FS3Combat.stopped_by_cover?(0, @combatant).should be false
-          FS3Combat.stopped_by_cover?(1, @combatant).should be false
-          FS3Combat.stub(:rand) { 49 }
-          FS3Combat.stopped_by_cover?(0, @combatant).should be true
-          FS3Combat.stopped_by_cover?(1, @combatant).should be true
+          allow(FS3Combat).to receive(:rand) { 51 }
+          expect(FS3Combat.stopped_by_cover?(0, @combatant)).to be false
+          expect(FS3Combat.stopped_by_cover?(1, @combatant)).to be false
+          allow(FS3Combat).to receive(:rand) { 49 }
+          expect(FS3Combat.stopped_by_cover?(0, @combatant)).to be true
+          expect(FS3Combat.stopped_by_cover?(1, @combatant)).to be true
         end
         
         it "should have 25% cover for a decent attack roll" do
 
-          FS3Combat.stub(:rand) { 26 }
-          FS3Combat.stopped_by_cover?(2, @combatant).should be false
-          FS3Combat.stub(:rand) { 24 }
-          FS3Combat.stopped_by_cover?(2, @combatant).should be true
+          allow(FS3Combat).to receive(:rand) { 26 }
+          expect(FS3Combat.stopped_by_cover?(2, @combatant)).to be false
+          allow(FS3Combat).to receive(:rand) { 24 }
+          expect(FS3Combat.stopped_by_cover?(2, @combatant)).to be true
         end
       end
       
@@ -411,45 +411,45 @@ module AresMUSH
         before do 
           @combatant = double
           @target = double
-          @combatant.stub(:log)
+          allow(@combatant).to receive(:log)
         end
         
         it "should not hit mount if there's no mount" do
-          @target.stub(:mount_type) { nil }
-          FS3Combat.should_not_receive(:rand) { 0 }
-          FS3Combat.hit_mount?(@combatant, @target, 0, false).should be false
+          allow(@target).to receive(:mount_type) { nil }
+          expect(FS3Combat).to_not receive(:rand) { 0 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 0, false)).to be false
         end
         
         it "should have 0% for a good attack roll" do
-          @target.stub(:mount_type) { "Horse" }
-          FS3Combat.stub(:rand) { 1 }
-          FS3Combat.hit_mount?(@combatant, @target, 3, false).should be false
+          allow(@target).to receive(:mount_type) { "Horse" }
+          allow(FS3Combat).to receive(:rand) { 1 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 3, false)).to be false
         end
         
         it "should have 20% when attacker mounted" do
-          @target.stub(:mount_type) { "Horse" }
-          @combatant.stub(:mount_type) { "Horse" }
-          FS3Combat.stub(:rand) { 19 }
-          FS3Combat.hit_mount?(@combatant, @target, 0, false).should be true
-          FS3Combat.stub(:rand) { 21 }
-          FS3Combat.hit_mount?(@combatant, @target, 0, false).should be false
+          allow(@target).to receive(:mount_type) { "Horse" }
+          allow(@combatant).to receive(:mount_type) { "Horse" }
+          allow(FS3Combat).to receive(:rand) { 19 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 0, false)).to be true
+          allow(FS3Combat).to receive(:rand) { 21 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 0, false)).to be false
         end        
         
         it "should have 40% when attacker dismounted" do
-          @target.stub(:mount_type) { "Horse" }
-          @combatant.stub(:mount_type) { nil }
-          FS3Combat.stub(:rand) { 39 }
-          FS3Combat.hit_mount?(@combatant, @target, 0, false).should be true
-          FS3Combat.stub(:rand) { 41 }
-          FS3Combat.hit_mount?(@combatant, @target, 0, false).should be false
+          allow(@target).to receive(:mount_type) { "Horse" }
+          allow(@combatant).to receive(:mount_type) { nil }
+          allow(FS3Combat).to receive(:rand) { 39 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 0, false)).to be true
+          allow(FS3Combat).to receive(:rand) { 41 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 0, false)).to be false
         end
         
         it "should have 90% when mount hit on purpose" do
-          @target.stub(:mount_type) { "Horse" }
-          FS3Combat.stub(:rand) { 89 }
-          FS3Combat.hit_mount?(@combatant, @target, 3, true).should be true
-          FS3Combat.stub(:rand) { 91 }
-          FS3Combat.hit_mount?(@combatant, @target, 3, true).should be false          
+          allow(@target).to receive(:mount_type) { "Horse" }
+          allow(FS3Combat).to receive(:rand) { 89 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 3, true)).to be true
+          allow(FS3Combat).to receive(:rand) { 91 }
+          expect(FS3Combat.hit_mount?(@combatant, @target, 3, true)).to be false          
         end
         
       end
@@ -458,270 +458,270 @@ module AresMUSH
       describe :determine_damage do
         before do 
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:damage_lethality_mod) { 0 }
-          @combatant.stub(:is_npc?) { false }
-          FS3Combat.stub(:hitloc_severity).with(@combatant, "Chest", false) { "Vital" }
-          FS3Combat.stub(:weapon_stat).with("Knife", "lethality") { 0 }
-          FS3Combat.stub(:rand) { 0 }
-          Global.stub(:read_config).with("fs3combat", "damage_table") { { "GRAZE" => 20, "FLESH" => 60, "IMPAIR" => 100 } }
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:damage_lethality_mod) { 0 }
+          allow(@combatant).to receive(:is_npc?) { false }
+          allow(FS3Combat).to receive(:hitloc_severity).with(@combatant, "Chest", false) { "Vital" }
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "lethality") { 0 }
+          allow(FS3Combat).to receive(:rand) { 0 }
+          allow(Global).to receive(:read_config).with("fs3combat", "damage_table") { { "GRAZE" => 20, "FLESH" => 60, "IMPAIR" => 100 } }
           
         end
   
         describe "random damage" do
           it "should roll a graze" do
-            FS3Combat.stub(:rand) { 19 }
-            FS3Combat.determine_damage(@combatant, "Chest", "Knife").should eq "GRAZE"
+            allow(FS3Combat).to receive(:rand) { 19 }
+            expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife")).to eq "GRAZE"
           end
           
           it "should roll a flesh wound" do
-            FS3Combat.stub(:rand) { 59 }
-            FS3Combat.determine_damage(@combatant, "Chest", "Knife").should eq "FLESH"
+            allow(FS3Combat).to receive(:rand) { 59 }
+            expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife")).to eq "FLESH"
           end
           
           it "should roll an impairing wound" do
-            FS3Combat.stub(:rand) { 80 }
-            FS3Combat.determine_damage(@combatant, "Chest", "Knife").should eq "IMPAIR"
+            allow(FS3Combat).to receive(:rand) { 80 }
+            expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife")).to eq "IMPAIR"
           end
           
           it "should roll an incap wound" do
-            FS3Combat.stub(:rand) { 101 }
-            FS3Combat.determine_damage(@combatant, "Chest", "Knife").should eq "INCAP"
+            allow(FS3Combat).to receive(:rand) { 101 }
+            expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife")).to eq "INCAP"
           end
         end
   
         it "should pass along a crew hit" do
-          FS3Combat.stub(:hitloc_severity).with(@combatant, "Chest", true) { "Normal" }
-          FS3Combat.determine_damage(@combatant, "Chest", "Knife", 0, true).should eq "GRAZE"
+          allow(FS3Combat).to receive(:hitloc_severity).with(@combatant, "Chest", true) { "Normal" }
+          expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife", 0, true)).to eq "GRAZE"
         end
         
         it "should account for lethality" do
-          FS3Combat.stub(:weapon_stat).with("Knife", "lethality") { 40 }
-          FS3Combat.determine_damage(@combatant, "Chest", "Knife").should eq "FLESH"
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "lethality") { 40 }
+          expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife")).to eq "FLESH"
         end
 
         it "should account for hitloc severity for non-vital" do
-          FS3Combat.stub(:rand) { 29 }
-          FS3Combat.stub(:hitloc_severity).with(@combatant, "Chest", false) { "Normal" }
-          FS3Combat.determine_damage(@combatant, "Chest", "Knife").should eq "GRAZE"
+          allow(FS3Combat).to receive(:rand) { 29 }
+          allow(FS3Combat).to receive(:hitloc_severity).with(@combatant, "Chest", false) { "Normal" }
+          expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife")).to eq "GRAZE"
         end
 
         it "should account for hitloc severity for critical" do
-          FS3Combat.stub(:hitloc_severity).with(@combatant, "Chest", false) { "Critical" }
-          FS3Combat.stub(:rand) { 80 }
-          FS3Combat.stub(:weapon_stat).with("Knife", "lethality") { 0 }
-          FS3Combat.determine_damage(@combatant, "Chest", "Knife").should eq "INCAP"
+          allow(FS3Combat).to receive(:hitloc_severity).with(@combatant, "Chest", false) { "Critical" }
+          allow(FS3Combat).to receive(:rand) { 80 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "lethality") { 0 }
+          expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife")).to eq "INCAP"
         end
   
         it "should account for armor" do
-          FS3Combat.stub(:rand) { 24 }
-          FS3Combat.determine_damage(@combatant, "Chest", "Knife", -5).should eq "GRAZE"
+          allow(FS3Combat).to receive(:rand) { 24 }
+          expect(FS3Combat.determine_damage(@combatant, "Chest", "Knife", -5)).to eq "GRAZE"
         end
       end
       
       describe :determine_armor do
         before do 
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:vehicle) { nil }
-          @combatant.stub(:armor) { "Tactical" }
-          FS3Skills.stub(:one_shot_die_roll) { { successes: 0 } }
-          FS3Combat.stub(:weapon_stat) { 5 }
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:vehicle) { nil }
+          allow(@combatant).to receive(:armor) { "Tactical" }
+          allow(FS3Skills).to receive(:one_shot_die_roll) { { successes: 0 } }
+          allow(FS3Combat).to receive(:weapon_stat) { 5 }
         end
 
         it "should return no protection if no armor" do
-          @combatant.stub(:armor) { nil }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0).should eq 0
+          allow(@combatant).to receive(:armor) { nil }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)).to eq 0
         end
         
         it "should get protection from vehicle armor if in a vehicle" do
           vehicle = double
-          vehicle.stub(:armor) { "Viper" }
-          @combatant.stub(:vehicle) { vehicle }
+          allow(vehicle).to receive(:armor) { "Viper" }
+          allow(@combatant).to receive(:vehicle) { vehicle }
           
-          FS3Combat.should_receive(:armor_stat).with("Viper", "protection") { {} }
+          expect(FS3Combat).to receive(:armor_stat).with("Viper", "protection") { {} }
           FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)
         end
 
         it "should get protection from combatant armor if not in a vehicle" do
-          FS3Combat.should_receive(:armor_stat).with("Tactical", "protection") { {} }
+          expect(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { {} }
           FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)
         end
         
         it "should bypass armor if not a protected location" do
-          FS3Combat.stub(:armor_stat).with("Tactical", "protection") { { "Chest" => 2 } }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0).should eq 0
+          allow(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { { "Chest" => 2 } }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)).to eq 0
         end
         
         it "should bypass armor if weapon wins by enough" do
-          FS3Combat.stub(:rand).with(8) { 6 }
-          FS3Combat.stub(:weapon_stat).with("Rifle", "penetration") { 5 }
-          FS3Combat.stub(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0).should eq 0
+          allow(FS3Combat).to receive(:rand).with(8) { 6 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "penetration") { 5 }
+          allow(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)).to eq 0
         end
         
         it "should provide minimum armor xxx" do
-          FS3Combat.stub(:rand).with(8) { 4 }
-          FS3Combat.stub(:rand).with(25) { 24 }
-          FS3Combat.stub(:weapon_stat).with("Rifle", "penetration") { 5 }
-          FS3Combat.stub(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0).should eq 24
+          allow(FS3Combat).to receive(:rand).with(8) { 4 }
+          allow(FS3Combat).to receive(:rand).with(25) { 24 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "penetration") { 5 }
+          allow(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)).to eq 24
         end
 
         it "should provide some armor" do
-          FS3Combat.stub(:rand).with(8) { 2 }
-          FS3Combat.stub(:weapon_stat).with("Rifle", "penetration") { 5 }
-          FS3Combat.stub(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
-          FS3Combat.stub(:rand).with(25) { 19 }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0).should eq 44
+          allow(FS3Combat).to receive(:rand).with(8) { 2 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "penetration") { 5 }
+          allow(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
+          allow(FS3Combat).to receive(:rand).with(25) { 19 }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)).to eq 44
         end
 
         it "should provide extra armor" do
-          FS3Combat.stub(:rand).with(8) { 0 }
-          FS3Combat.stub(:weapon_stat).with("Rifle", "penetration") { 5 }
-          FS3Combat.stub(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
-          FS3Combat.stub(:rand).with(50) { 15 }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0).should eq 65
+          allow(FS3Combat).to receive(:rand).with(8) { 0 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "penetration") { 5 }
+          allow(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { { "Head" => 3 } }
+          allow(FS3Combat).to receive(:rand).with(50) { 15 }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)).to eq 65
         end
 
         it "should stop attack if armor wins by enough" do
-          FS3Combat.stub(:rand).with(8) { 1 }
-          FS3Combat.stub(:weapon_stat).with("Rifle", "penetration") { 5 }
-          FS3Combat.stub(:armor_stat).with("Tactical", "protection") { { "Head" => 6 } }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0).should eq 100
+          allow(FS3Combat).to receive(:rand).with(8) { 1 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "penetration") { 5 }
+          allow(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { { "Head" => 6 } }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 0)).to eq 100
         end
 
         it "should add in attacker successes for to pen roll" do
-          FS3Combat.stub(:rand).with(8) { 8 }
-          FS3Combat.stub(:weapon_stat).with("Rifle", "penetration") { 3 }
-          FS3Combat.stub(:armor_stat).with("Tactical", "protection") { { "Head" => 5 } }
-          FS3Combat.determine_armor(@combatant, "Head", "Rifle", 2).should eq 0
+          allow(FS3Combat).to receive(:rand).with(8) { 8 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "penetration") { 3 }
+          allow(FS3Combat).to receive(:armor_stat).with("Tactical", "protection") { { "Head" => 5 } }
+          expect(FS3Combat.determine_armor(@combatant, "Head", "Rifle", 2)).to eq 0
         end        
       end
       
       describe :determine_attack_margin do
         before do
           @combatant = double
-          @combatant.stub(:log)
+          allow(@combatant).to receive(:log)
           @target = double
           
-          @combatant.stub(:name) { "A" }
-          @target.stub(:name) { "D" }
+          allow(@combatant).to receive(:name) { "A" }
+          allow(@target).to receive(:name) { "D" }
           
-          @combatant.stub(:recoil) { 0 }
-          @combatant.stub(:weapon) { "Rifle" }
-          @target.stub(:stance) { "Normal" }
+          allow(@combatant).to receive(:recoil) { 0 }
+          allow(@combatant).to receive(:weapon) { "Rifle" }
+          allow(@target).to receive(:stance) { "Normal" }
           
-          FS3Combat.stub(:hit_mount?) { false }
+          allow(FS3Combat).to receive(:hit_mount?) { false }
         end
         
         it "should roll attack and defense" do
-          FS3Combat.should_receive(:roll_attack).with(@combatant, @target, 0) { 0 }
-          FS3Combat.should_receive(:roll_defense).with(@target, "Rifle") { 0 }
+          expect(FS3Combat).to receive(:roll_attack).with(@combatant, @target, 0) { 0 }
+          expect(FS3Combat).to receive(:roll_defense).with(@target, "Rifle") { 0 }
           FS3Combat.determine_attack_margin(@combatant, @target, 0)
         end
         
         it "should add in an attacker modifier" do
-          FS3Combat.should_receive(:roll_attack).with(@combatant, @target, 1) { 0 }
-          FS3Combat.should_receive(:roll_defense).with(@target, "Rifle") { 0 }
+          expect(FS3Combat).to receive(:roll_attack).with(@combatant, @target, 1) { 0 }
+          expect(FS3Combat).to receive(:roll_defense).with(@target, "Rifle") { 0 }
           FS3Combat.determine_attack_margin(@combatant, @target, 1)
         end
         
         it "should subtract recoil" do
-          @combatant.stub(:recoil) { 2 }
-          FS3Combat.should_receive(:roll_attack).with(@combatant, @target, -2) { 0 }
-          FS3Combat.should_receive(:roll_defense).with(@target, "Rifle") { 0 }
+          allow(@combatant).to receive(:recoil) { 2 }
+          expect(FS3Combat).to receive(:roll_attack).with(@combatant, @target, -2) { 0 }
+          expect(FS3Combat).to receive(:roll_defense).with(@target, "Rifle") { 0 }
           FS3Combat.determine_attack_margin(@combatant, @target, 0)
         end
         
         it "should be a dodge if the defender wins when attacked by melee" do
-          @combatant.stub(:weapon) { "Knife" }
-          FS3Combat.stub(:weapon_stat).with("Knife", "weapon_type") { "Melee" }
-          FS3Combat.stub(:roll_attack) { 1 }
-          FS3Combat.stub(:roll_defense) { 2 }
+          allow(@combatant).to receive(:weapon) { "Knife" }
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "weapon_type") { "Melee" }
+          allow(FS3Combat).to receive(:roll_attack) { 1 }
+          allow(FS3Combat).to receive(:roll_defense) { 2 }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should eq "fs3combat.attack_dodged"
-          result[:hit].should eq false
+          expect(result[:message]).to eq "fs3combat.attack_dodged"
+          expect(result[:hit]).to eq false
         end
         
         it "should be a dodge easily if defender wins by a lot vs melee" do
-          FS3Combat.stub(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
-          FS3Combat.stub(:roll_attack) { 1 }
-          FS3Combat.stub(:roll_defense) { 4 }
-          @target.stub(:is_in_vehicle?) { true }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
+          allow(FS3Combat).to receive(:roll_attack) { 1 }
+          allow(FS3Combat).to receive(:roll_defense) { 4 }
+          allow(@target).to receive(:is_in_vehicle?) { true }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should eq "fs3combat.attack_dodged_easily"
-          result[:hit].should eq false
+          expect(result[:message]).to eq "fs3combat.attack_dodged_easily"
+          expect(result[:hit]).to eq false
         end
         
         it "should be a dodge if the defender wins when in vehicle" do
-          FS3Combat.stub(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
-          FS3Combat.stub(:roll_attack) { 1 }
-          FS3Combat.stub(:roll_defense) { 2 }
-          @target.stub(:is_in_vehicle?) { true }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
+          allow(FS3Combat).to receive(:roll_attack) { 1 }
+          allow(FS3Combat).to receive(:roll_defense) { 2 }
+          allow(@target).to receive(:is_in_vehicle?) { true }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should eq "fs3combat.attack_dodged"
-          result[:hit].should eq false
+          expect(result[:message]).to eq "fs3combat.attack_dodged"
+          expect(result[:hit]).to eq false
         end
         
         it "should be a near miss if defender wins vs ranged" do
-          FS3Combat.stub(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
-          FS3Combat.stub(:roll_attack) { 1 }
-          FS3Combat.stub(:roll_defense) { 2 }
-          @target.stub(:is_in_vehicle?) { false }
+          allow(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
+          allow(FS3Combat).to receive(:roll_attack) { 1 }
+          allow(FS3Combat).to receive(:roll_defense) { 2 }
+          allow(@target).to receive(:is_in_vehicle?) { false }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should eq "fs3combat.attack_near_miss"
-          result[:hit].should eq false
+          expect(result[:message]).to eq "fs3combat.attack_near_miss"
+          expect(result[:hit]).to eq false
         end
         
         it "should hit cover if defender is in cover and cover applies" do
-          @target.stub(:stance) { "Cover" }
-          FS3Combat.should_receive(:stopped_by_cover?).with(2, @combatant) { true }
-          FS3Combat.stub(:roll_attack) { 3 }
-          FS3Combat.stub(:roll_defense) { 1 }
+          allow(@target).to receive(:stance) { "Cover" }
+          expect(FS3Combat).to receive(:stopped_by_cover?).with(2, @combatant) { true }
+          allow(FS3Combat).to receive(:roll_attack) { 3 }
+          allow(FS3Combat).to receive(:roll_defense) { 1 }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should eq "fs3combat.attack_hits_cover"
-          result[:hit].should eq false
+          expect(result[:message]).to eq "fs3combat.attack_hits_cover"
+          expect(result[:hit]).to eq false
         end
 
         it "should be hit if the attacker ties" do
-          FS3Combat.stub(:roll_attack) { 2 }
-          FS3Combat.stub(:roll_defense) { 2 }
+          allow(FS3Combat).to receive(:roll_attack) { 2 }
+          allow(FS3Combat).to receive(:roll_defense) { 2 }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should be_nil
-          result[:attacker_net_successes].should eq 0
-          result[:hit].should eq true
+          expect(result[:message]).to be_nil
+          expect(result[:attacker_net_successes]).to eq 0
+          expect(result[:hit]).to eq true
         end
         
         it "should have a chance to hit mount" do
-          FS3Combat.should_receive(:hit_mount?).with(@combatant, @target, 1, false) { true }
-          FS3Combat.should_receive(:resolve_mount_ko).with(@target) { false }
-          FS3Combat.stub(:roll_attack) { 3 }
-          FS3Combat.stub(:roll_defense) { 2 }
+          expect(FS3Combat).to receive(:hit_mount?).with(@combatant, @target, 1, false) { true }
+          expect(FS3Combat).to receive(:resolve_mount_ko).with(@target) { false }
+          allow(FS3Combat).to receive(:roll_attack) { 3 }
+          allow(FS3Combat).to receive(:roll_defense) { 2 }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should eq "fs3combat.attack_hits_mount"
-          result[:hit].should eq false
+          expect(result[:message]).to eq "fs3combat.attack_hits_mount"
+          expect(result[:hit]).to eq false
         end
         
         it "should ko mount if hit badly" do
-          FS3Combat.should_receive(:hit_mount?).with(@combatant, @target, 1, false) { true }
-          FS3Combat.should_receive(:resolve_mount_ko).with(@target) { true }
-          FS3Combat.stub(:roll_attack) { 3 }
-          FS3Combat.stub(:roll_defense) { 2 }
-          @target.should_receive(:inflict_damage).with("IMPAIR", "Fall Damage", true, false)
-          @target.should_receive(:update).with(:mount_type => nil)
+          expect(FS3Combat).to receive(:hit_mount?).with(@combatant, @target, 1, false) { true }
+          expect(FS3Combat).to receive(:resolve_mount_ko).with(@target) { true }
+          allow(FS3Combat).to receive(:roll_attack) { 3 }
+          allow(FS3Combat).to receive(:roll_defense) { 2 }
+          expect(@target).to receive(:inflict_damage).with("IMPAIR", "Fall Damage", true, false)
+          expect(@target).to receive(:update).with(:mount_type => nil)
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should eq "fs3combat.attack_hits_mount"
-          result[:hit].should eq false
+          expect(result[:message]).to eq "fs3combat.attack_hits_mount"
+          expect(result[:hit]).to eq false
         end
 
         it "should be hit if the attacker wins" do
-          FS3Combat.stub(:roll_attack) { 4 }
-          FS3Combat.stub(:roll_defense) { 2 }
+          allow(FS3Combat).to receive(:roll_attack) { 4 }
+          allow(FS3Combat).to receive(:roll_defense) { 2 }
           result = FS3Combat.determine_attack_margin(@combatant, @target, 0)
-          result[:message].should be_nil
-          result[:attacker_net_successes].should eq 2
-          result[:hit].should eq true
+          expect(result[:message]).to be_nil
+          expect(result[:attacker_net_successes]).to eq 2
+          expect(result[:hit]).to eq true
         end
       end
       
@@ -729,64 +729,64 @@ module AresMUSH
         before do
           @target = double
           @combatant = double
-          @combatant.stub(:log)
-          @combatant.stub(:weapon) { "Knife" }
-          FS3Combat.stub(:weapon_stat).with("Knife", "recoil") { 1 }
-          @combatant.stub(:recoil) { 0 }
-          @combatant.stub(:update)
-          @target.stub(:riding_in) { nil }
-          @combatant.stub(:name) { "A" }
-          FS3Combat.stub(:determine_attack_margin) { { hit: true, attacker_net_successes: 2 }}
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:weapon) { "Knife" }
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "recoil") { 1 }
+          allow(@combatant).to receive(:recoil) { 0 }
+          allow(@combatant).to receive(:update)
+          allow(@target).to receive(:riding_in) { nil }
+          allow(@combatant).to receive(:name) { "A" }
+          allow(FS3Combat).to receive(:determine_attack_margin) { { hit: true, attacker_net_successes: 2 }}
           
-          FS3Combat.stub(:resolve_attack)
+          allow(FS3Combat).to receive(:resolve_attack)
         end
         
         it "should return margin message if a miss" do
-          FS3Combat.should_receive(:determine_attack_margin).with(@combatant, @target, 0, nil, false) { { hit: false, message: "dodged" }}
-          FS3Combat.attack_target(@combatant, @target).should eq ["dodged"]
+          expect(FS3Combat).to receive(:determine_attack_margin).with(@combatant, @target, 0, nil, false) { { hit: false, message: "dodged" }}
+          expect(FS3Combat.attack_target(@combatant, @target)).to eq ["dodged"]
         end
         
         it "should pass along the attack mod" do
-          FS3Combat.should_receive(:determine_attack_margin).with(@combatant, @target, -1, nil, false) { { hit: false, message: "dodged" }}
+          expect(FS3Combat).to receive(:determine_attack_margin).with(@combatant, @target, -1, nil, false) { { hit: false, message: "dodged" }}
           FS3Combat.attack_target(@combatant, @target, -1)
         end
         
         it "should update recoil" do
-          @combatant.stub(:recoil) { 5 }
-          @combatant.should_receive(:update).with(recoil: 6)
+          allow(@combatant).to receive(:recoil) { 5 }
+          expect(@combatant).to receive(:update).with(recoil: 6)
           FS3Combat.attack_target(@combatant, @target)
         end
         
         it "should resolve the attack" do
-          FS3Combat.should_receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, nil, false)
+          expect(FS3Combat).to receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, nil, false)
           FS3Combat.attack_target(@combatant, @target)
         end
         
         it "should resolve the attack with a called shot and mod" do
-          FS3Combat.should_receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, "Head", false)
+          expect(FS3Combat).to receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, "Head", false)
           FS3Combat.attack_target(@combatant, @target, 3, "Head")
         end
         
         it "should resolve the attack with a crew hit" do
-          FS3Combat.should_receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, nil, true)
+          expect(FS3Combat).to receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, nil, true)
           FS3Combat.attack_target(@combatant, @target, 3, nil, true)
         end
         
         it "should attack the pilot when the passenger is targeted" do
           pilot = double
           vehicle = double
-          @target.stub(:riding_in) { vehicle }
-          vehicle.stub(:pilot) { pilot }
-          FS3Combat.should_receive(:resolve_attack).with(@combatant, "A", pilot, "Knife", 2, nil, false)
+          allow(@target).to receive(:riding_in) { vehicle }
+          allow(vehicle).to receive(:pilot) { pilot }
+          expect(FS3Combat).to receive(:resolve_attack).with(@combatant, "A", pilot, "Knife", 2, nil, false)
           FS3Combat.attack_target(@combatant, @target)
         end
 
         it "should not attack a non-existent pilot if a passenger is targeted" do
           pilot = double
           vehicle = double
-          @target.stub(:riding_in) { vehicle }
-          vehicle.stub(:pilot) { nil }
-          FS3Combat.should_receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, nil, false)
+          allow(@target).to receive(:riding_in) { vehicle }
+          allow(vehicle).to receive(:pilot) { nil }
+          expect(FS3Combat).to receive(:resolve_attack).with(@combatant, "A", @target, "Knife", 2, nil, false)
           FS3Combat.attack_target(@combatant, @target)
         end
       end
@@ -797,118 +797,118 @@ module AresMUSH
         before do
           @target = double
           @combatant = double
-          FS3Combat.stub(:determine_armor) { 0 }
-          FS3Combat.stub(:determine_damage) { "GRAZE" }
-          FS3Combat.stub(:weapon_is_stun?) { false }
-          FS3Combat.stub(:determine_hitloc) { "Chest" }
-          FS3Combat.stub(:resolve_possible_crew_hit) { [] }
-          FS3Combat.stub(:weapon_stat) { "x" }
-          @target.stub(:log)
-          @target.stub(:inflict_damage)
-          @target.stub(:name) { "D" }
-          @target.stub(:add_stress)
-          @target.stub(:update).with(freshly_damaged: true)
-          @target.stub(:damaged_by) { [] }
-          @target.stub(:luck) { "" }
-          @target.stub(:update).with(damaged_by: [ "A" ]) {}
-          @combatant.stub(:luck) { "" }
+          allow(FS3Combat).to receive(:determine_armor) { 0 }
+          allow(FS3Combat).to receive(:determine_damage) { "GRAZE" }
+          allow(FS3Combat).to receive(:weapon_is_stun?) { false }
+          allow(FS3Combat).to receive(:determine_hitloc) { "Chest" }
+          allow(FS3Combat).to receive(:resolve_possible_crew_hit) { [] }
+          allow(FS3Combat).to receive(:weapon_stat) { "x" }
+          allow(@target).to receive(:log)
+          allow(@target).to receive(:inflict_damage)
+          allow(@target).to receive(:name) { "D" }
+          allow(@target).to receive(:add_stress)
+          allow(@target).to receive(:update).with(freshly_damaged: true)
+          allow(@target).to receive(:damaged_by) { [] }
+          allow(@target).to receive(:luck) { "" }
+          allow(@target).to receive(:update).with(damaged_by: [ "A" ]) {}
+          allow(@combatant).to receive(:luck) { "" }
         end
             
         
         it "should determine hit location if no called shot" do
-          FS3Combat.should_receive(:determine_hitloc).with(@target, 0, nil, false) { "Head" }
+          expect(FS3Combat).to receive(:determine_hitloc).with(@target, 0, nil, false) { "Head" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
 
         it "should determine hit location if called shot" do
-          FS3Combat.should_receive(:determine_hitloc).with(@target, 0, "Arm", false) { "Hand" }
+          expect(FS3Combat).to receive(:determine_hitloc).with(@target, 0, "Arm", false) { "Hand" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife", 0, "Arm")
         end
         
         it "should return armor message if stopped by armor" do
-          FS3Combat.should_receive(:determine_armor).with(@target, "Chest", "Knife", 2) { 110 }
-          FS3Combat.resolve_attack(@combatant, "A", @target, "Knife", 2).should eq ["fs3combat.attack_stopped_by_armor"]
+          expect(FS3Combat).to receive(:determine_armor).with(@target, "Chest", "Knife", 2) { 110 }
+          expect(FS3Combat.resolve_attack(@combatant, "A", @target, "Knife", 2)).to eq ["fs3combat.attack_stopped_by_armor"]
         end
         
         it "should reduce damage if armor slowed the attack" do
-          FS3Combat.stub(:determine_armor) { 22 }
-          FS3Combat.should_receive(:determine_damage).with(@target, "Chest", "Knife", -22, false) { "INCAP" }
+          allow(FS3Combat).to receive(:determine_armor) { 22 }
+          expect(FS3Combat).to receive(:determine_damage).with(@target, "Chest", "Knife", -22, false) { "INCAP" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
         
         it "should update damaged by xxx" do 
-          @target.stub(:damaged_by) { [ "X" ] }
-          @target.should_receive(:update).with(damaged_by: [ "X", "A" ])
-          FS3Combat.should_receive(:determine_damage).with(@target, "Chest", "Knife", 0, false) { "INCAP" }
+          allow(@target).to receive(:damaged_by) { [ "X" ] }
+          expect(@target).to receive(:update).with(damaged_by: [ "X", "A" ])
+          expect(FS3Combat).to receive(:determine_damage).with(@target, "Chest", "Knife", 0, false) { "INCAP" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
         
         it "should add success to damage" do
-          FS3Combat.should_receive(:determine_damage).with(@target, "Chest", "Knife", 15, false) { "INCAP" }
+          expect(FS3Combat).to receive(:determine_damage).with(@target, "Chest", "Knife", 15, false) { "INCAP" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife", 4)
         end
         
         it "should add strength to damage if using a melee weapon" do
-          FS3Combat.stub(:weapon_stat).with("Knife", "weapon_type") { "Melee" }
-          FS3Combat.stub(:roll_strength).with(@combatant) { 3 }          
-          FS3Combat.should_receive(:determine_damage).with(@target, "Chest", "Knife", 10, false) { "INCAP" }
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "weapon_type") { "Melee" }
+          allow(FS3Combat).to receive(:roll_strength).with(@combatant) { 3 }          
+          expect(FS3Combat).to receive(:determine_damage).with(@target, "Chest", "Knife", 10, false) { "INCAP" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
         
         
         it "should add luck to damage if luck spent on attack" do
-          FS3Combat.stub(:determine_armor) { 22 }
-          @combatant.stub(:luck) { "Attack" }
-          FS3Combat.should_receive(:determine_damage).with(@target, "Chest", "Knife", 8, false) { "INCAP" }
+          allow(FS3Combat).to receive(:determine_armor) { 22 }
+          allow(@combatant).to receive(:luck) { "Attack" }
+          expect(FS3Combat).to receive(:determine_damage).with(@target, "Chest", "Knife", 8, false) { "INCAP" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
         
         it "should subtract luck from damage if luck spent on defense" do
-          FS3Combat.stub(:determine_armor) { 22 }
-          @target.stub(:luck) { "Defense" }
-          FS3Combat.should_receive(:determine_damage).with(@target, "Chest", "Knife", -52, false) { "INCAP" }
+          allow(FS3Combat).to receive(:determine_armor) { 22 }
+          allow(@target).to receive(:luck) { "Defense" }
+          expect(FS3Combat).to receive(:determine_damage).with(@target, "Chest", "Knife", -52, false) { "INCAP" }
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
         
         it "should inflict damage" do
-          @target.should_receive(:inflict_damage).with("GRAZE", "Knife - Chest", false, false)
+          expect(@target).to receive(:inflict_damage).with("GRAZE", "Knife - Chest", false, false)
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end      
         
         it "should mark as freshly damaged" do
-          FS3Combat.stub(:determine_damage) { "FLESH" }
-          @target.should_receive(:update).with(freshly_damaged: true)
+          allow(FS3Combat).to receive(:determine_damage) { "FLESH" }
+          expect(@target).to receive(:update).with(freshly_damaged: true)
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
         
         it "should not mark as freshly damaged for a graze wound" do
-          FS3Combat.stub(:determine_damage) { "GRAZE" }
-          @target.should_not_receive(:update).with(freshly_damaged: true)
+          allow(FS3Combat).to receive(:determine_damage) { "GRAZE" }
+          expect(@target).to_not receive(:update).with(freshly_damaged: true)
           FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")
         end
 
         it "should return a hit message" do
-          FS3Combat.resolve_attack(@combatant, "A", @target, "Knife").should eq ["fs3combat.attack_hits"]
+          expect(FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")).to eq ["fs3combat.attack_hits"]
         end
         
         it "should add a stress point" do
-          @target.should_receive(:add_stress).with(1)
-          FS3Combat.resolve_attack(@combatant, "A", @target, "Knife").should eq ["fs3combat.attack_hits"]
+          expect(@target).to receive(:add_stress).with(1)
+          expect(FS3Combat.resolve_attack(@combatant, "A", @target, "Knife")).to eq ["fs3combat.attack_hits"]
         end
         
         it "should pass along a crew hit" do
-          @target.should_receive(:inflict_damage).with("GRAZE", "Knife - Chest", false, true)
-          FS3Combat.resolve_attack(@combatant, "A", @target, "Knife", 0, nil, true).should eq ["fs3combat.attack_hits"]
+          expect(@target).to receive(:inflict_damage).with("GRAZE", "Knife - Chest", false, true)
+          expect(FS3Combat.resolve_attack(@combatant, "A", @target, "Knife", 0, nil, true)).to eq ["fs3combat.attack_hits"]
         end
       end
       
       describe :resolve_possible_crew_hit do
         before do
           @target = double
-          @target.stub(:is_in_vehicle?) { true }
-          @target.stub(:log)
+          allow(@target).to receive(:is_in_vehicle?) { true }
+          allow(@target).to receive(:log)
           @vehicle = double
-          FS3Combat.stub(:hitloc_chart).with(@target) { { "crew_areas" => ["Cockpit"] } }
+          allow(FS3Combat).to receive(:hitloc_chart).with(@target) { { "crew_areas" => ["Cockpit"] } }
           
           # By seeding the kernel random number generator, the first two shrapnel rolls
           # will always be 2, 1.
@@ -917,30 +917,30 @@ module AresMUSH
         end
         
         it "should return nothing if not in vehicle" do
-          @target.stub(:is_in_vehicle?) { false }
-          FS3Combat.resolve_possible_crew_hit(@target, "Body", "GRAZE").should eq []
+          allow(@target).to receive(:is_in_vehicle?) { false }
+          expect(FS3Combat.resolve_possible_crew_hit(@target, "Body", "GRAZE")).to eq []
         end
         
         it "should not do damage if not a crew hitloc xxx" do
-          @target.stub(:vehicle) { @vehicle}
-          FS3Combat.resolve_possible_crew_hit(@target, "Body", "GRAZE").should eq []
+          allow(@target).to receive(:vehicle) { @vehicle}
+          expect(FS3Combat.resolve_possible_crew_hit(@target, "Body", "GRAZE")).to eq []
         end
         
         it "should inflict shrapnel to each passenger" do
           p1 = double
           p2 = double
-          p1.stub(:name) { "a" }
-          p2.stub(:name) { "b" }
+          allow(p1).to receive(:name) { "a" }
+          allow(p2).to receive(:name) { "b" }
           
           
-          @target.stub(:vehicle) { @vehicle }
-          @vehicle.stub(:passengers) { [p1] }
-          @vehicle.stub(:pilot) { p2 }
-          FS3Combat.should_receive(:resolve_attack).with(nil, t('fs3combat.crew_hit'), p1, "Shrapnel", 0, nil, true) { ["a1"]}
-          FS3Combat.should_receive(:resolve_attack).with(nil, t('fs3combat.crew_hit'), p1, "Shrapnel", 0, nil, true) { ["a2"]}
-          FS3Combat.should_receive(:resolve_attack).with(nil, t('fs3combat.crew_hit'), p2, "Shrapnel", 0, nil, true) { ["a3"]}
+          allow(@target).to receive(:vehicle) { @vehicle }
+          allow(@vehicle).to receive(:passengers) { [p1] }
+          allow(@vehicle).to receive(:pilot) { p2 }
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, t('fs3combat.crew_hit'), p1, "Shrapnel", 0, nil, true) { ["a1"]}
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, t('fs3combat.crew_hit'), p1, "Shrapnel", 0, nil, true) { ["a2"]}
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, t('fs3combat.crew_hit'), p2, "Shrapnel", 0, nil, true) { ["a3"]}
 
-          FS3Combat.resolve_possible_crew_hit(@target, "Cockpit", "IMPAIR").should eq ["a1", "a2", "a3"]
+          expect(FS3Combat.resolve_possible_crew_hit(@target, "Cockpit", "IMPAIR")).to eq ["a1", "a2", "a3"]
         end
         
       end
@@ -948,26 +948,26 @@ module AresMUSH
       describe :resolve_mount_ko do
         before do
           @target = double
-          @target.stub(:mount_type) { "Horse" }
-          @target.stub(:log)
+          allow(@target).to receive(:mount_type) { "Horse" }
+          allow(@target).to receive(:log)
         end
         
         it "should factor in mount toughness" do
-          FS3Combat.stub(:mount_stat).with("Horse", "toughness") { 2 }
-          FS3Skills.should_receive(:one_shot_die_roll).with(2) { { successes: 0 } }
+          allow(FS3Combat).to receive(:mount_stat).with("Horse", "toughness") { 2 }
+          expect(FS3Skills).to receive(:one_shot_die_roll).with(2) { { successes: 0 } }
           FS3Combat.resolve_mount_ko(@target)
         end
         
         it "should be KOed with a bad roll" do
-          FS3Combat.stub(:mount_stat).with("Horse", "toughness") { 2 }
-          FS3Skills.should_receive(:one_shot_die_roll).with(2) { { successes: 0 } }
-          FS3Combat.resolve_mount_ko(@target).should eq true
+          allow(FS3Combat).to receive(:mount_stat).with("Horse", "toughness") { 2 }
+          expect(FS3Skills).to receive(:one_shot_die_roll).with(2) { { successes: 0 } }
+          expect(FS3Combat.resolve_mount_ko(@target)).to eq true
         end
         
         it "should not be KOed with a good roll" do
-          FS3Combat.stub(:mount_stat).with("Horse", "toughness") { 2 }
-          FS3Skills.should_receive(:one_shot_die_roll).with(2) { { successes: 3 } }
-          FS3Combat.resolve_mount_ko(@target).should eq false
+          allow(FS3Combat).to receive(:mount_stat).with("Horse", "toughness") { 2 }
+          expect(FS3Skills).to receive(:one_shot_die_roll).with(2) { { successes: 3 } }
+          expect(FS3Combat.resolve_mount_ko(@target)).to eq false
         end
         
       end

--- a/plugins/fs3combat/specs/actions/attack_action_specs.rb
+++ b/plugins/fs3combat/specs/actions/attack_action_specs.rb
@@ -6,194 +6,194 @@ module AresMUSH
         @target = double
         @combat = double
 
-        @combat.stub(:find_combatant) { @target }
-        @combatant.stub(:combat) { @combat }
-        @combatant.stub(:weapon) { "Rifle" }
-        @combatant.stub(:name) { "A" }
-        FS3Combat.stub(:hitloc_areas) { [] }
-        @target.stub(:name) { "Target" }
-        @target.stub(:is_noncombatant?) { false }
-        FS3Combat.stub(:weapon_stat) { "" }
-        FS3Combat.stub(:check_ammo) { true }
-        FS3Combat.stub(:update_ammo) { nil }
-        SpecHelpers.stub_translate_for_testing
+        allow(@combat).to receive(:find_combatant) { @target }
+        allow(@combatant).to receive(:combat) { @combat }
+        allow(@combatant).to receive(:weapon) { "Rifle" }
+        allow(@combatant).to receive(:name) { "A" }
+        allow(FS3Combat).to receive(:hitloc_areas) { [] }
+        allow(@target).to receive(:name) { "Target" }
+        allow(@target).to receive(:is_noncombatant?) { false }
+        allow(FS3Combat).to receive(:weapon_stat) { "" }
+        allow(FS3Combat).to receive(:check_ammo) { true }
+        allow(FS3Combat).to receive(:update_ammo) { nil }
+        stub_translate_for_testing
       end
       
       describe :prepare do
         it "should parse simple taget" do
           @action = AttackAction.new(@combatant, " target ")
-          @action.prepare.should be_nil
-          @action.is_burst.should be false
-          @action.called_shot.should be_nil
-          @action.crew_hit.should eq false
-          @action.mod.should eq 0
+          expect(@action.prepare).to be_nil
+          expect(@action.is_burst).to be false
+          expect(@action.called_shot).to be_nil
+          expect(@action.crew_hit).to eq false
+          expect(@action.mod).to eq 0
         end
         
         it "should parse target plus mod" do
           @action = AttackAction.new(@combatant, "target/mod:3")
-          @action.prepare.should be_nil
-          @action.is_burst.should be false
-          @action.called_shot.should be_nil
-          @action.crew_hit.should eq false
-          @action.mod.should eq 3
+          expect(@action.prepare).to be_nil
+          expect(@action.is_burst).to be false
+          expect(@action.called_shot).to be_nil
+          expect(@action.crew_hit).to eq false
+          expect(@action.mod).to eq 3
         end
         
         it "should parse target plus called" do
           @action = AttackAction.new(@combatant, "target/called:head")
-          FS3Combat.stub(:has_hitloc?).with(@target, "Head") { true }
-          @action.prepare.should be_nil
-          @action.is_burst.should be false
-          @action.called_shot.should eq "Head"
-          @action.crew_hit.should eq false
-          @action.mod.should eq 0
+          allow(FS3Combat).to receive(:has_hitloc?).with(@target, "Head") { true }
+          expect(@action.prepare).to be_nil
+          expect(@action.is_burst).to be false
+          expect(@action.called_shot).to eq "Head"
+          expect(@action.crew_hit).to eq false
+          expect(@action.mod).to eq 0
         end
         
         it "should parse target plus called and crew" do
-          FS3Combat.stub(:has_hitloc?).with(@target, "Head") { true }
+          allow(FS3Combat).to receive(:has_hitloc?).with(@target, "Head") { true }
           @action = AttackAction.new(@combatant, "target/called:head,crew")
-          @action.prepare.should be_nil
-          @action.is_burst.should be false
-          @action.called_shot.should eq "Head"
-          @action.crew_hit.should eq true
-          @action.mod.should eq 0
+          expect(@action.prepare).to be_nil
+          expect(@action.is_burst).to be false
+          expect(@action.called_shot).to eq "Head"
+          expect(@action.crew_hit).to eq true
+          expect(@action.mod).to eq 0
         end
         
         it "should parse mod plus burst" do
           @action = AttackAction.new(@combatant, "target/burst,mod:3")
-          @target.stub(:hitloc_areas) { ["Head"] }
-          @action.prepare.should be_nil
-          @action.is_burst.should be true
-          @action.called_shot.should be_nil
-          @action.crew_hit.should eq false
-          @action.mod.should eq 3
+          allow(@target).to receive(:hitloc_areas) { ["Head"] }
+          expect(@action.prepare).to be_nil
+          expect(@action.is_burst).to be true
+          expect(@action.called_shot).to be_nil
+          expect(@action.crew_hit).to eq false
+          expect(@action.mod).to eq 3
         end
         
         it "should raise error for invalid called shot location" do
-          FS3Combat.stub(:has_hitloc?).with(@target, "Head") { false }
+          allow(FS3Combat).to receive(:has_hitloc?).with(@target, "Head") { false }
           @action = AttackAction.new(@combatant, "target/called:head")
-          @action.prepare.should eq "fs3combat.invalid_called_shot_loc"
+          expect(@action.prepare).to eq "fs3combat.invalid_called_shot_loc"
         end
         
         it "should raise error for invalid special" do
           @action = AttackAction.new(@combatant, "target/foo:3")
-          @action.prepare.should eq "fs3combat.invalid_attack_special"
+          expect(@action.prepare).to eq "fs3combat.invalid_attack_special"
         end
         
         it "should fail if multiple targets" do
           @action = AttackAction.new(@combatant, "target1 target2")
-          @action.prepare.should eq "fs3combat.only_one_target"
+          expect(@action.prepare).to eq "fs3combat.only_one_target"
         end
         
         it "should fail if out of ammo" do
-          FS3Combat.should_receive(:check_ammo).with(@combatant, 1) { false }
+          expect(FS3Combat).to receive(:check_ammo).with(@combatant, 1) { false }
           @action = AttackAction.new(@combatant, "target")
-          @action.prepare.should eq "fs3combat.out_of_ammo"
+          expect(@action.prepare).to eq "fs3combat.out_of_ammo"
         end
 
         it "should fail if not enough ammo for a burst" do
-          FS3Combat.should_receive(:check_ammo).with(@combatant, 2) { false }
+          expect(FS3Combat).to receive(:check_ammo).with(@combatant, 2) { false }
           @action = AttackAction.new(@combatant, "target/burst")
-          @action.prepare.should eq "fs3combat.not_enough_ammo_for_burst"
+          expect(@action.prepare).to eq "fs3combat.not_enough_ammo_for_burst"
         end
 
         it "should fail if trying to burst with non-auto weapon" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "is_automatic") { false }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "is_automatic") { false }
           @action = AttackAction.new(@combatant, "target/burst")
-          @action.prepare.should eq "fs3combat.burst_fire_not_allowed"
+          expect(@action.prepare).to eq "fs3combat.burst_fire_not_allowed"
         end
 
         it "should fail if trying to burst with called shot" do
-          @target.stub(:hitloc_areas) { ["Head"] }
+          allow(@target).to receive(:hitloc_areas) { ["Head"] }
           @action = AttackAction.new(@combatant, "target/called:head , burst")
-          @action.prepare.should eq "fs3combat.no_fullauto_called_shots"
+          expect(@action.prepare).to eq "fs3combat.no_fullauto_called_shots"
         end
 
         it "should warn if using an explosive weapon" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
           @action = AttackAction.new(@combatant, "target1 target2")
-          @action.prepare.should eq "fs3combat.use_explode_command"
+          expect(@action.prepare).to eq "fs3combat.use_explode_command"
         end
 
         it "should warn if using a suppressive weapon" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Suppressive" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Suppressive" }
           @action = AttackAction.new(@combatant, "target1 target2")
-          @action.prepare.should eq "fs3combat.use_suppress_command"
+          expect(@action.prepare).to eq "fs3combat.use_suppress_command"
         end
 
         it "should succeed" do
           @action = AttackAction.new(@combatant, "target")
-          @action.prepare.should be_nil
-          @action.targets.should eq [ @target ]
+          expect(@action.prepare).to be_nil
+          expect(@action.targets).to eq [ @target ]
         end
       end
       
       describe :resolve do
         before do
-          @combatant.stub(:update)
+          allow(@combatant).to receive(:update)
           @action = AttackAction.new(@combatant, "target")
           @action.prepare
-          @combatant.stub(:ammo) { 5 }
-          FS3Combat.stub(:attack_target) { ["resultx"] }
+          allow(@combatant).to receive(:ammo) { 5 }
+          allow(FS3Combat).to receive(:attack_target) { ["resultx"] }
         end
           
         it "should attack in single fire" do
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
           resolutions = @action.resolve
-          resolutions[0].should eq "result1"
-          resolutions.count.should eq 1
+          expect(resolutions[0]).to eq "result1"
+          expect(resolutions.count).to eq 1
         end
         
         it "should attack in burst fire" do
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result2"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result3"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result2"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result3"] }
           @action.is_burst = true
           resolutions = @action.resolve
-          resolutions[0].should eq "fs3combat.fires_burst"
-          resolutions[1].should eq "result1"
-          resolutions[2].should eq "result2"
-          resolutions[3].should eq "result3"
-          resolutions.count.should eq 4
+          expect(resolutions[0]).to eq "fs3combat.fires_burst"
+          expect(resolutions[1]).to eq "result1"
+          expect(resolutions[2]).to eq "result2"
+          expect(resolutions[3]).to eq "result3"
+          expect(resolutions.count).to eq 4
         end
         
         it "should limit burst fire to the number of bullets" do
-          @combatant.stub(:ammo) { 2 }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result2"] }
+          allow(@combatant).to receive(:ammo) { 2 }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result2"] }
           @action.is_burst = true
           resolutions = @action.resolve
-          resolutions[0].should eq "fs3combat.fires_burst"
-          resolutions[1].should eq "result1"
-          resolutions[2].should eq "result2"
-          resolutions.count.should eq 3
+          expect(resolutions[0]).to eq "fs3combat.fires_burst"
+          expect(resolutions[1]).to eq "result1"
+          expect(resolutions[2]).to eq "result2"
+          expect(resolutions.count).to eq 3
         end
         
         it "should update ammo for a single shot" do
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 1)
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 1)
           @action.resolve
         end
 
         it "should update ammo for a burst" do
           @action.is_burst = true
-          @combatant.stub(:attack_target) { "result" }
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 3)
+          allow(@combatant).to receive(:attack_target) { "result" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 3)
           @action.resolve
         end
         
         it "should update ammo for a burst with limited ammo" do
-          @combatant.stub(:ammo) { 2 }
+          allow(@combatant).to receive(:ammo) { 2 }
           @action.is_burst = true
-          @combatant.stub(:attack_target) { "result" }
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 2)
+          allow(@combatant).to receive(:attack_target) { "result" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 2)
           @action.resolve
         end
         
         it "should add an out of ammo message" do
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 1) { "out of ammo" }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target, 0, nil, false, false) { ["result1"] }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 1) { "out of ammo" }
           resolutions = @action.resolve
-          resolutions[0].should eq "result1"
-          resolutions[1].should eq "out of ammo"
+          expect(resolutions[0]).to eq "result1"
+          expect(resolutions[1]).to eq "out of ammo"
         end
       end
     end

--- a/plugins/fs3combat/specs/actions/combat_action_specs.rb
+++ b/plugins/fs3combat/specs/actions/combat_action_specs.rb
@@ -2,7 +2,7 @@ module AresMUSH
   module FS3Combat
     describe CombatAction do
       before do
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
 
       describe :parse_targets do
@@ -11,35 +11,35 @@ module AresMUSH
           @target1 = double
           @target2 = double
           @combatant = double
-          @combatant.stub(:combat) { @combat }
-          @target1.stub(:is_noncombatant?) { false }
-          @target2.stub(:is_noncombatant?) { false }
+          allow(@combatant).to receive(:combat) { @combat }
+          allow(@target1).to receive(:is_noncombatant?) { false }
+          allow(@target2).to receive(:is_noncombatant?) { false }
         end
   
         it "should return error if combatant not found" do
-          @combat.stub(:find_combatant).with("A") { @target1 }
-          @combat.stub(:find_combatant).with("B") { nil }
+          allow(@combat).to receive(:find_combatant).with("A") { @target1 }
+          allow(@combat).to receive(:find_combatant).with("B") { nil }
           action = CombatAction.new(@combatant, "a b")
-          action.parse_targets("a b").should eq "fs3combat.not_in_combat"
-          action.targets.should eq []
+          expect(action.parse_targets("a b")).to eq "fs3combat.not_in_combat"
+          expect(action.targets).to eq []
         end
   
         it "should return error if targeting a non-combatant" do
-          @combat.stub(:find_combatant).with("A") { @target1 }
-          @combat.stub(:find_combatant).with("B") { @target2 }
-          @target2.stub(:is_noncombatant?) { true }
+          allow(@combat).to receive(:find_combatant).with("A") { @target1 }
+          allow(@combat).to receive(:find_combatant).with("B") { @target2 }
+          allow(@target2).to receive(:is_noncombatant?) { true }
           action = CombatAction.new(@combatant, "a b")
-          action.parse_targets("a b").should eq "fs3combat.cant_target_noncombatant"
-          action.targets.should eq []
+          expect(action.parse_targets("a b")).to eq "fs3combat.cant_target_noncombatant"
+          expect(action.targets).to eq []
         end
   
         it "should return names and list of targets" do
-          @combat.stub(:find_combatant).with("A") { @target1 }
-          @combat.stub(:find_combatant).with("B") { @target2 }
+          allow(@combat).to receive(:find_combatant).with("A") { @target1 }
+          allow(@combat).to receive(:find_combatant).with("B") { @target2 }
 
           action = CombatAction.new(@combatant, "a b")
-          action.parse_targets("a b").should be_nil
-          action.targets.should eq [ @target1, @target2 ]
+          expect(action.parse_targets("a b")).to be_nil
+          expect(action.targets).to eq [ @target1, @target2 ]
         end
       end
     end

--- a/plugins/fs3combat/specs/actions/escape_action_specs.rb
+++ b/plugins/fs3combat/specs/actions/escape_action_specs.rb
@@ -6,73 +6,73 @@ module AresMUSH
         @combat = double
         @subduer = double
         
-        @combatant.stub(:combat) { @combat }
-        @combatant.stub(:name) { "A" }
-        FS3Combat.stub(:weapon_stat) { "" }
-        SpecHelpers.stub_translate_for_testing
+        allow(@combatant).to receive(:combat) { @combat }
+        allow(@combatant).to receive(:name) { "A" }
+        allow(FS3Combat).to receive(:weapon_stat) { "" }
+        stub_translate_for_testing
       end
       
       describe :prepare do
         before do
-          @combat.stub(:find_combatant) { @target }
+          allow(@combat).to receive(:find_combatant) { @target }
         end
         
         it "should fail if not subdued" do
-          @combatant.stub(:is_subdued?) { false }
+          allow(@combatant).to receive(:is_subdued?) { false }
           @action = EscapeAction.new(@combatant, "")
-          @action.prepare.should eq "fs3combat.not_subdued"
+          expect(@action.prepare).to eq "fs3combat.not_subdued"
         end
         
         it "should succeed if subdued" do
-          @combatant.stub(:is_subdued?) { true }
-          @combatant.stub(:subdued_by) { @subduer }
+          allow(@combatant).to receive(:is_subdued?) { true }
+          allow(@combatant).to receive(:subdued_by) { @subduer }
           @action = EscapeAction.new(@combatant, "")
-          @action.prepare.should be_nil
-          @action.subduer.should eq @subduer
+          expect(@action.prepare).to be_nil
+          expect(@action.subduer).to eq @subduer
         end
       end
       
       describe :resolve do
         before do
-          @subduer.stub(:name) { "Bob" }
-          @combatant.stub(:is_subdued?) { true }
-          @combatant.stub(:subdued_by) { @subduer }
+          allow(@subduer).to receive(:name) { "Bob" }
+          allow(@combatant).to receive(:is_subdued?) { true }
+          allow(@combatant).to receive(:subdued_by) { @subduer }
         end
           
         it "should escape automatically if subduer is no longer subduing" do
-          @combatant.stub(:is_subdued?) { false }
-          @combatant.should_receive(:update).with(subdued_by: nil)
-          @combatant.should_receive(:update).with(action_klass: nil)
-          @combatant.should_receive(:update).with(action_args: nil)
+          allow(@combatant).to receive(:is_subdued?) { false }
+          expect(@combatant).to receive(:update).with(subdued_by: nil)
+          expect(@combatant).to receive(:update).with(action_klass: nil)
+          expect(@combatant).to receive(:update).with(action_args: nil)
 
           @action = EscapeAction.new(@combatant, "")
           @action.prepare
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.escape_action_success" ]
+          expect(resolutions).to eq [ "fs3combat.escape_action_success" ]
         end
         
         it "should escape with a failed subdue roll" do
-          @combatant.should_receive(:update).with(subdued_by: nil)
-          @combatant.should_receive(:update).with(action_klass: nil)
-          @combatant.should_receive(:update).with(action_args: nil)
+          expect(@combatant).to receive(:update).with(subdued_by: nil)
+          expect(@combatant).to receive(:update).with(action_klass: nil)
+          expect(@combatant).to receive(:update).with(action_args: nil)
           @action = EscapeAction.new(@combatant, "")
           @action.prepare
           
-          FS3Combat.stub(:determine_attack_margin).with(@subduer, @combatant) { {hit: false} }
+          allow(FS3Combat).to receive(:determine_attack_margin).with(@subduer, @combatant) { {hit: false} }
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.escape_action_success" ]
+          expect(resolutions).to eq [ "fs3combat.escape_action_success" ]
         end
 
         it "should stay subdued with a successful subdue roll" do
-          @combatant.should_not_receive(:update).with(subdued_by: nil)
-          @combatant.should_not_receive(:update).with(action_klass: nil)
-          @combatant.should_not_receive(:update).with(action_args: nil)
+          expect(@combatant).to_not receive(:update).with(subdued_by: nil)
+          expect(@combatant).to_not receive(:update).with(action_klass: nil)
+          expect(@combatant).to_not receive(:update).with(action_args: nil)
           @action = EscapeAction.new(@combatant, "")
           @action.prepare
           
-          FS3Combat.stub(:determine_attack_margin).with(@subduer, @combatant) { {hit: true} }
+          allow(FS3Combat).to receive(:determine_attack_margin).with(@subduer, @combatant) { {hit: true} }
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.escape_action_failed" ]
+          expect(resolutions).to eq [ "fs3combat.escape_action_failed" ]
         end
         
       end

--- a/plugins/fs3combat/specs/actions/explode_action_specs.rb
+++ b/plugins/fs3combat/specs/actions/explode_action_specs.rb
@@ -5,46 +5,46 @@ module AresMUSH
         @combatant = double
         @combat = double
 
-        @combatant.stub(:combat) { @combat }
-        @combatant.stub(:weapon) { "Missile" }
-        FS3Combat.stub(:check_ammo) { true }
-        FS3Combat.stub(:update_ammo) { nil }
-        @combatant.stub(:name) { "A" }
-        FS3Combat.stub(:weapon_stat) { "" }
-        FS3Combat.stub(:weapon_stat).with("Missile", "weapon_type") { "Explosive" }
-        SpecHelpers.stub_translate_for_testing
+        allow(@combatant).to receive(:combat) { @combat }
+        allow(@combatant).to receive(:weapon) { "Missile" }
+        allow(FS3Combat).to receive(:check_ammo) { true }
+        allow(FS3Combat).to receive(:update_ammo) { nil }
+        allow(@combatant).to receive(:name) { "A" }
+        allow(FS3Combat).to receive(:weapon_stat) { "" }
+        allow(FS3Combat).to receive(:weapon_stat).with("Missile", "weapon_type") { "Explosive" }
+        stub_translate_for_testing
       end
       
       describe :prepare do
         before do
-          @combat.stub(:find_combatant) { @target }
+          allow(@combat).to receive(:find_combatant) { @target }
           @target = double
-          @target.stub(:name) { "Target" }
-          @target.stub(:is_noncombatant?) { false }
+          allow(@target).to receive(:name) { "Target" }
+          allow(@target).to receive(:is_noncombatant?) { false }
         end
         
         
         it "should fail if too many targets" do
           @action = ExplodeAction.new(@combatant, "target1 target2 taget3 target4")
-          @action.prepare.should eq "fs3combat.too_many_targets"
+          expect(@action.prepare).to eq "fs3combat.too_many_targets"
         end
         
         it "should fail if not enough ammot" do
-          FS3Combat.should_receive(:check_ammo).with(@combatant, 1) { false }
+          expect(FS3Combat).to receive(:check_ammo).with(@combatant, 1) { false }
           @action = ExplodeAction.new(@combatant, "target")
-          @action.prepare.should eq "fs3combat.out_of_ammo"
+          expect(@action.prepare).to eq "fs3combat.out_of_ammo"
         end
 
         it "should fail if trying to use a non-explosive weapon" do
-          FS3Combat.should_receive(:weapon_stat).with("Missile", "weapon_type") { "Ranged" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Missile", "weapon_type") { "Ranged" }
           @action = ExplodeAction.new(@combatant, "target")
-          @action.prepare.should eq "fs3combat.not_explosive_weapon"
+          expect(@action.prepare).to eq "fs3combat.not_explosive_weapon"
         end
 
         it "should succeed" do
           @action = ExplodeAction.new(@combatant, "target1 target2")
-          @action.prepare.should be_nil
-          @action.targets.should eq [ @target, @target ]
+          expect(@action.prepare).to be_nil
+          expect(@action.targets).to eq [ @target, @target ]
         end
       end
       
@@ -53,20 +53,20 @@ module AresMUSH
           @target1 = double
           @target2 = double
           @target3 = double
-          @target1.stub(:name) { "T1" }
-          @target2.stub(:name) { "T2" }
-          @target3.stub(:name) { "T3" }
-          @target1.stub(:is_noncombatant?) { false }
-          @target2.stub(:is_noncombatant?) { false }
-          @target3.stub(:is_noncombatant?) { false }
+          allow(@target1).to receive(:name) { "T1" }
+          allow(@target2).to receive(:name) { "T2" }
+          allow(@target3).to receive(:name) { "T3" }
+          allow(@target1).to receive(:is_noncombatant?) { false }
+          allow(@target2).to receive(:is_noncombatant?) { false }
+          allow(@target3).to receive(:is_noncombatant?) { false }
 
-          @combatant.stub(:update)
-          @combatant.stub(:ammo) { 10 }
-          @combat.stub(:find_combatant).with("Target1") { @target1 }
-          @combat.stub(:find_combatant).with("Target2") { @target2 }
-          @combat.stub(:find_combatant).with("Target3") { @target3 }
-          FS3Combat.stub(:attack_target) { ["resultx"] }
-          FS3Combat.stub(:weapon_stat).with("Missile", "has_shrapnel") { false }
+          allow(@combatant).to receive(:update)
+          allow(@combatant).to receive(:ammo) { 10 }
+          allow(@combat).to receive(:find_combatant).with("Target1") { @target1 }
+          allow(@combat).to receive(:find_combatant).with("Target2") { @target2 }
+          allow(@combat).to receive(:find_combatant).with("Target3") { @target3 }
+          allow(FS3Combat).to receive(:attack_target) { ["resultx"] }
+          allow(FS3Combat).to receive(:weapon_stat).with("Missile", "has_shrapnel") { false }
           
           # By seeding the kernel random number generator, the first three shrapnel rolls
           # will always be 0, 4, 2.
@@ -76,45 +76,45 @@ module AresMUSH
         it "should attack with only explosives if no shrapnel" do
           @action = ExplodeAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result1"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target2) { ["result2"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target3) { ["result3"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target2) { ["result2"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target3) { ["result3"] }
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.explode_resolution_message", "result1", "result2", "result3" ]
+          expect(resolutions).to eq [ "fs3combat.explode_resolution_message", "result1", "result2", "result3" ]
         end
         
         it "should attack with explosives and shrapnel" do
-          FS3Combat.stub(:weapon_stat).with("Missile", "has_shrapnel") { true }
+          allow(FS3Combat).to receive(:weapon_stat).with("Missile", "has_shrapnel") { true }
           @action = ExplodeAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result1"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target2) { ["result2"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target3) { ["result3"] }
-          FS3Combat.should_receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel1"] }
-          FS3Combat.should_receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel2"] }
-          FS3Combat.should_receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel3"] }
-          FS3Combat.should_receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel4"] }
-          FS3Combat.should_receive(:resolve_attack).with(nil, "A", @target3, "Shrapnel" ) { ["shrapnel5"] }
-          FS3Combat.should_receive(:resolve_attack).with(nil, "A", @target3, "Shrapnel" ) { ["shrapnel6"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target2) { ["result2"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target3) { ["result3"] }
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel1"] }
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel2"] }
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel3"] }
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, "A", @target2, "Shrapnel" ) { ["shrapnel4"] }
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, "A", @target3, "Shrapnel" ) { ["shrapnel5"] }
+          expect(FS3Combat).to receive(:resolve_attack).with(nil, "A", @target3, "Shrapnel" ) { ["shrapnel6"] }
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.explode_resolution_message", "result1", "result2", "shrapnel1",
+          expect(resolutions).to eq [ "fs3combat.explode_resolution_message", "result1", "result2", "shrapnel1",
             "shrapnel2", "shrapnel3", "shrapnel4", "result3", "shrapnel5", "shrapnel6" ]
         end
         
         it "should update ammo" do
           @action = ExplodeAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          @combatant.stub(:attack_target) { "result" }
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 1)
+          allow(@combatant).to receive(:attack_target) { "result" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 1)
           @action.resolve
         end
         
         it "should add an out of ammo message" do
           @action = ExplodeAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 1) { "out of ammo" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 1) { "out of ammo" }
           resolutions = @action.resolve
-          resolutions[resolutions.count - 1].should eq "out of ammo"
+          expect(resolutions[resolutions.count - 1]).to eq "out of ammo"
         end
       end
     end

--- a/plugins/fs3combat/specs/actions/fullauto_action_specs.rb
+++ b/plugins/fs3combat/specs/actions/fullauto_action_specs.rb
@@ -5,57 +5,57 @@ module AresMUSH
         @combatant = double
         @combat = double
 
-        @combatant.stub(:combat) { @combat }
-        @combatant.stub(:weapon) { "Rifle" }
-        FS3Combat.stub(:check_ammo) { true }
-        FS3Combat.stub(:update_ammo) { nil }
-        @combatant.stub(:name) { "A" }
-        FS3Combat.stub(:weapon_stat) { "" }
-        SpecHelpers.stub_translate_for_testing
+        allow(@combatant).to receive(:combat) { @combat }
+        allow(@combatant).to receive(:weapon) { "Rifle" }
+        allow(FS3Combat).to receive(:check_ammo) { true }
+        allow(FS3Combat).to receive(:update_ammo) { nil }
+        allow(@combatant).to receive(:name) { "A" }
+        allow(FS3Combat).to receive(:weapon_stat) { "" }
+        stub_translate_for_testing
       end
       
       describe :prepare do
         before do
-          @combat.stub(:find_combatant) { @target }
+          allow(@combat).to receive(:find_combatant) { @target }
           @target = double
-          @target.stub(:name) { "Target" }
-          @target.stub(:is_noncombatant?) { false }
+          allow(@target).to receive(:name) { "Target" }
+          allow(@target).to receive(:is_noncombatant?) { false }
         end
         
         
         it "should fail if too many targets" do
           @action = FullautoAction.new(@combatant, "target1 target2 taget3 target4")
-          @action.prepare.should eq "fs3combat.too_many_targets"
+          expect(@action.prepare).to eq "fs3combat.too_many_targets"
         end
         
         it "should fail if not enough ammo for a burst" do
-          FS3Combat.should_receive(:check_ammo).with(@combatant, 8) { false }
+          expect(FS3Combat).to receive(:check_ammo).with(@combatant, 8) { false }
           @action = FullautoAction.new(@combatant, "target")
-          @action.prepare.should eq "fs3combat.not_enough_ammo_for_fullauto"
+          expect(@action.prepare).to eq "fs3combat.not_enough_ammo_for_fullauto"
         end
 
         it "should fail if trying to burst with non-auto weapon" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "is_automatic") { false }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "is_automatic") { false }
           @action = FullautoAction.new(@combatant, "target")
-          @action.prepare.should eq "fs3combat.burst_fire_not_allowed"
+          expect(@action.prepare).to eq "fs3combat.burst_fire_not_allowed"
         end
 
         it "should warn if using an explosive weapon" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
           @action = FullautoAction.new(@combatant, "target1 target2")
-          @action.prepare.should eq "fs3combat.use_explode_command"
+          expect(@action.prepare).to eq "fs3combat.use_explode_command"
         end
 
         it "should warn if using a suppressive weapon" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Suppressive" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Suppressive" }
           @action = FullautoAction.new(@combatant, "target1 target2")
-          @action.prepare.should eq "fs3combat.use_suppress_command"
+          expect(@action.prepare).to eq "fs3combat.use_suppress_command"
         end
 
         it "should succeed" do
           @action = FullautoAction.new(@combatant, "target1 target2")
-          @action.prepare.should be_nil
-          @action.targets.should eq [ @target, @target ]
+          expect(@action.prepare).to be_nil
+          expect(@action.targets).to eq [ @target, @target ]
         end
       end
       
@@ -64,75 +64,75 @@ module AresMUSH
           @target1 = double
           @target2 = double
           @target3 = double
-          @target1.stub(:name) { "T1" }
-          @target2.stub(:name) { "T2" }
-          @target3.stub(:name) { "T3" }
-          @target1.stub(:is_noncombatant?) { false }
-          @target2.stub(:is_noncombatant?) { false }
-          @target3.stub(:is_noncombatant?) { false }
+          allow(@target1).to receive(:name) { "T1" }
+          allow(@target2).to receive(:name) { "T2" }
+          allow(@target3).to receive(:name) { "T3" }
+          allow(@target1).to receive(:is_noncombatant?) { false }
+          allow(@target2).to receive(:is_noncombatant?) { false }
+          allow(@target3).to receive(:is_noncombatant?) { false }
 
-          @combatant.stub(:update)
-          @combatant.stub(:ammo) { 10 }
-          @combat.stub(:find_combatant).with("Target1") { @target1 }
-          @combat.stub(:find_combatant).with("Target2") { @target2 }
-          @combat.stub(:find_combatant).with("Target3") { @target3 }
-          FS3Combat.stub(:attack_target) { ["resultx"] }
+          allow(@combatant).to receive(:update)
+          allow(@combatant).to receive(:ammo) { 10 }
+          allow(@combat).to receive(:find_combatant).with("Target1") { @target1 }
+          allow(@combat).to receive(:find_combatant).with("Target2") { @target2 }
+          allow(@combat).to receive(:find_combatant).with("Target3") { @target3 }
+          allow(FS3Combat).to receive(:attack_target) { ["resultx"] }
         end
           
         it "should attack a single target with all the bullets" do
           @action = FullautoAction.new(@combatant, "target1")
           @action.prepare
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result1"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result2"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result3"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result4"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result5"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result6"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result7"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result8"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result2"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result3"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result4"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result5"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result6"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result7"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result8"] }
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.fires_fullauto", "result1", "result2", "result3", "result4",
+          expect(resolutions).to eq [ "fs3combat.fires_fullauto", "result1", "result2", "result3", "result4",
             "result5", "result6", "result7", "result8" ]
         end
         
         it "should attack two targets with split bullets" do
           @action = FullautoAction.new(@combatant, "target1 target2")
           @action.prepare
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result1"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result2"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result3"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target2) { ["result4"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target2) { ["result5"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target2) { ["result6"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result2"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result3"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target2) { ["result4"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target2) { ["result5"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target2) { ["result6"] }
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.fires_fullauto", "result1", "result2", "result3", "result4",
+          expect(resolutions).to eq [ "fs3combat.fires_fullauto", "result1", "result2", "result3", "result4",
             "result5", "result6" ]
         end
         
         it "should attack three targets with split bullets" do
           @action = FullautoAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target1) { ["result1"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target2) { ["result2"] }
-          FS3Combat.should_receive(:attack_target).with(@combatant, @target3) { ["result3"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target1) { ["result1"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target2) { ["result2"] }
+          expect(FS3Combat).to receive(:attack_target).with(@combatant, @target3) { ["result3"] }
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.fires_fullauto", "result1", "result2", "result3" ]
+          expect(resolutions).to eq [ "fs3combat.fires_fullauto", "result1", "result2", "result3" ]
         end
         
         it "should update ammo" do
           @action = FullautoAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          @combatant.stub(:attack_target) { ["result"] }
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 8)
+          allow(@combatant).to receive(:attack_target) { ["result"] }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 8)
           @action.resolve
         end
         
         it "should add an out of ammo message" do
           @action = FullautoAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 8) { "out of ammo" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 8) { "out of ammo" }
           resolutions = @action.resolve
-          resolutions[resolutions.count - 1].should eq "out of ammo"
+          expect(resolutions[resolutions.count - 1]).to eq "out of ammo"
         end
       end
     end

--- a/plugins/fs3combat/specs/actions/suppress_action_specs.rb
+++ b/plugins/fs3combat/specs/actions/suppress_action_specs.rb
@@ -5,73 +5,73 @@ module AresMUSH
         @combatant = double
         @combat = double
 
-        @combatant.stub(:combat) { @combat }
-        @combatant.stub(:weapon) { "Rifle" }
-        FS3Combat.stub(:check_ammo) { true }
-        FS3Combat.stub(:update_ammo) { nil }
-        @combatant.stub(:name) { "A" }
-        FS3Combat.stub(:weapon_stat) { "" }
-        SpecHelpers.stub_translate_for_testing
+        allow(@combatant).to receive(:combat) { @combat }
+        allow(@combatant).to receive(:weapon) { "Rifle" }
+        allow(FS3Combat).to receive(:check_ammo) { true }
+        allow(FS3Combat).to receive(:update_ammo) { nil }
+        allow(@combatant).to receive(:name) { "A" }
+        allow(FS3Combat).to receive(:weapon_stat) { "" }
+        stub_translate_for_testing
       end
       
       describe :prepare do
         before do
-          @combat.stub(:find_combatant) { @target }
+          allow(@combat).to receive(:find_combatant) { @target }
           @target = double
-          @target.stub(:name) { "Target" }
-          @target.stub(:is_noncombatant?) { false }
+          allow(@target).to receive(:name) { "Target" }
+          allow(@target).to receive(:is_noncombatant?) { false }
         end
         
         
         it "should fail if too many targets for fullauto" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "is_automatic") { true }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Ranged" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "is_automatic") { true }
           @action = SuppressAction.new(@combatant, "target1 target2 taget3 target4")
-          @action.prepare.should eq "fs3combat.too_many_targets"
+          expect(@action.prepare).to eq "fs3combat.too_many_targets"
         end
         
         it "should fail if too many targets for explosives" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
           @action = SuppressAction.new(@combatant, "target1 target2 taget3 target4")
-          @action.prepare.should eq "fs3combat.too_many_targets"
+          expect(@action.prepare).to eq "fs3combat.too_many_targets"
         end
 
         it "should fail if too many targets for single shot" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "is_automatic") { false }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "is_automatic") { false }
           @action = SuppressAction.new(@combatant, "target1 target2")
-          @action.prepare.should eq "fs3combat.too_many_targets"
+          expect(@action.prepare).to eq "fs3combat.too_many_targets"
         end
         
         it "should fail if not enough ammo for a burst" do
-          FS3Combat.should_receive(:check_ammo).with(@combatant, 8) { false }
+          expect(FS3Combat).to receive(:check_ammo).with(@combatant, 8) { false }
           @action = SuppressAction.new(@combatant, "target1 target2")
-          @action.prepare.should eq "fs3combat.not_enough_ammo_for_fullauto"
+          expect(@action.prepare).to eq "fs3combat.not_enough_ammo_for_fullauto"
         end
 
         it "should fail if tnot enough ammo for a single shot" do
-          FS3Combat.should_receive(:check_ammo).with(@combatant, 1) { false }
+          expect(FS3Combat).to receive(:check_ammo).with(@combatant, 1) { false }
           @action = SuppressAction.new(@combatant, "target")
-          @action.prepare.should eq "fs3combat.out_of_ammo"
+          expect(@action.prepare).to eq "fs3combat.out_of_ammo"
         end
 
         it "should allow multiple targets for fullauto" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "is_automatic") { true }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "is_automatic") { true }
           @action = SuppressAction.new(@combatant, "target1 target2 target3")
-          @action.prepare.should be_nil
-          @action.targets.should eq [ @target, @target, @target ]
+          expect(@action.prepare).to be_nil
+          expect(@action.targets).to eq [ @target, @target, @target ]
         end
         
         it "should allow multiple targets for explosive" do
-          FS3Combat.should_receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rifle", "weapon_type") { "Explosive" }
           @action = SuppressAction.new(@combatant, "target1 target2 target3")
-          @action.prepare.should be_nil
-          @action.targets.should eq [ @target, @target, @target ]
+          expect(@action.prepare).to be_nil
+          expect(@action.targets).to eq [ @target, @target, @target ]
         end
         
         it "should allow a single target" do
           @action = SuppressAction.new(@combatant, "target")
-          @action.prepare.should be_nil
-          @action.targets.should eq [ @target ]
+          expect(@action.prepare).to be_nil
+          expect(@action.targets).to eq [ @target ]
         end
       end
       
@@ -80,82 +80,82 @@ module AresMUSH
           @target1 = double
           @target2 = double
           @target3 = double
-          @target1.stub(:name) { "T1" }
-          @target2.stub(:name) { "T2" }
-          @target3.stub(:name) { "T3" }
-          @target1.stub(:is_noncombatant?) { false }
-          @target2.stub(:is_noncombatant?) { false }
-          @target3.stub(:is_noncombatant?) { false }
+          allow(@target1).to receive(:name) { "T1" }
+          allow(@target2).to receive(:name) { "T2" }
+          allow(@target3).to receive(:name) { "T3" }
+          allow(@target1).to receive(:is_noncombatant?) { false }
+          allow(@target2).to receive(:is_noncombatant?) { false }
+          allow(@target3).to receive(:is_noncombatant?) { false }
 
-          @combatant.stub(:update)
-          @combatant.stub(:log)
-          @combatant.stub(:ammo) { 10 }
-          @combat.stub(:find_combatant).with("Target1") { @target1 }
-          @combat.stub(:find_combatant).with("Target2") { @target2 }
-          @combat.stub(:find_combatant).with("Target3") { @target3 }
-          FS3Combat.stub(:roll_attack) { 1 }
-          @target1.stub(:roll_ability) { 2 }
-          @target2.stub(:roll_ability) { 2 }
-          @target3.stub(:roll_ability) { 2 }
-          Global.stub(:read_config).with("fs3combat", "composure_skill") { "Composure" }
+          allow(@combatant).to receive(:update)
+          allow(@combatant).to receive(:log)
+          allow(@combatant).to receive(:ammo) { 10 }
+          allow(@combat).to receive(:find_combatant).with("Target1") { @target1 }
+          allow(@combat).to receive(:find_combatant).with("Target2") { @target2 }
+          allow(@combat).to receive(:find_combatant).with("Target3") { @target3 }
+          allow(FS3Combat).to receive(:roll_attack) { 1 }
+          allow(@target1).to receive(:roll_ability) { 2 }
+          allow(@target2).to receive(:roll_ability) { 2 }
+          allow(@target3).to receive(:roll_ability) { 2 }
+          allow(Global).to receive(:read_config).with("fs3combat", "composure_skill") { "Composure" }
         end
           
         it "should suppress a single target successfully" do
           @action = SuppressAction.new(@combatant, "target1")
           @action.prepare
-          FS3Combat.should_receive(:roll_attack).with(@combatant, @target1) { 2 }
-          @target1.should_receive(:roll_ability).with("Composure") { 0 }
-          @target1.should_receive(:add_stress).with(4)
+          expect(FS3Combat).to receive(:roll_attack).with(@combatant, @target1) { 2 }
+          expect(@target1).to receive(:roll_ability).with("Composure") { 0 }
+          expect(@target1).to receive(:add_stress).with(4)
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.suppress_successful_msg" ]
+          expect(resolutions).to eq [ "fs3combat.suppress_successful_msg" ]
         end
 
         it "should suppress a single target unsuccessfully" do
           @action = SuppressAction.new(@combatant, "target1")
           @action.prepare
-          FS3Combat.should_receive(:roll_attack).with(@combatant, @target1) { 0 }
-          @target1.should_receive(:roll_ability).with("Composure") { 1 }
-          @target1.should_not_receive(:add_stress)
+          expect(FS3Combat).to receive(:roll_attack).with(@combatant, @target1) { 0 }
+          expect(@target1).to receive(:roll_ability).with("Composure") { 1 }
+          expect(@target1).to_not receive(:add_stress)
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.suppress_failed_msg" ]
+          expect(resolutions).to eq [ "fs3combat.suppress_failed_msg" ]
         end
 
         
         it "should suppress multiple targets with separate rolls" do
           @action = SuppressAction.new(@combatant, "target1 target2")
           @action.prepare
-          FS3Combat.should_receive(:roll_attack).with(@combatant, @target1) { 2 }
-          FS3Combat.should_receive(:roll_attack).with(@combatant, @target2) { 1 }
-          @target1.should_receive(:roll_ability).with("Composure") { 0 }
-          @target2.should_receive(:roll_ability).with("Composure") { 3 }
-          @target1.should_receive(:add_stress).with(4)
-          @target2.should_not_receive(:add_stress)
+          expect(FS3Combat).to receive(:roll_attack).with(@combatant, @target1) { 2 }
+          expect(FS3Combat).to receive(:roll_attack).with(@combatant, @target2) { 1 }
+          expect(@target1).to receive(:roll_ability).with("Composure") { 0 }
+          expect(@target2).to receive(:roll_ability).with("Composure") { 3 }
+          expect(@target1).to receive(:add_stress).with(4)
+          expect(@target2).to_not receive(:add_stress)
           resolutions = @action.resolve
-          resolutions.should eq [ "fs3combat.suppress_successful_msg", "fs3combat.suppress_failed_msg" ]
+          expect(resolutions).to eq [ "fs3combat.suppress_successful_msg", "fs3combat.suppress_failed_msg" ]
         end
         
         it "should update ammo for multiple targets" do
           @action = SuppressAction.new(@combatant, "target1 target2 target3")
           @action.prepare
-          @combatant.stub(:attack_target) { "result" }
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 8)
+          allow(@combatant).to receive(:attack_target) { "result" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 8)
           @action.resolve
         end
         
         it "should update ammo for a single targets" do
           @action = SuppressAction.new(@combatant, "target1")
           @action.prepare
-          @combatant.stub(:attack_target) { "result" }
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 1)
+          allow(@combatant).to receive(:attack_target) { "result" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 1)
           @action.resolve
         end
         
         it "should add an out of ammo message" do
           @action = SuppressAction.new(@combatant, "target1")
           @action.prepare
-          FS3Combat.should_receive(:update_ammo).with(@combatant, 1) { "out of ammo" }
+          expect(FS3Combat).to receive(:update_ammo).with(@combatant, 1) { "out of ammo" }
           resolutions = @action.resolve
-          resolutions[resolutions.count - 1].should eq "out of ammo"
+          expect(resolutions[resolutions.count - 1]).to eq "out of ammo"
         end
       end
     end

--- a/plugins/fs3combat/specs/combat_instance_specs.rb
+++ b/plugins/fs3combat/specs/combat_instance_specs.rb
@@ -4,38 +4,38 @@ module AresMUSH
       
       before do
         @instance = Combat.new
-        @instance.stub(:save) { }
-        @instance.stub(:log) { }
+        allow(@instance).to receive(:save) { }
+        allow(@instance).to receive(:log) { }
         @bob = double
-        @bob.stub(:name) { "Bob" }
+        allow(@bob).to receive(:name) { "Bob" }
         
         @harvey = double
-        @harvey.stub(:name) { "Harvey" }
+        allow(@harvey).to receive(:name) { "Harvey" }
         
-        @instance.stub(:combatants) { [ @bob, @harvey ] }
+        allow(@instance).to receive(:combatants) { [ @bob, @harvey ] }
         
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
       
             
       describe :has_combatant? do
         it "should return true if there is someone with the name" do
-          @instance.has_combatant?("Bob").should be true
-          @instance.has_combatant?("bOb").should be true
+          expect(@instance.has_combatant?("Bob")).to be true
+          expect(@instance.has_combatant?("bOb")).to be true
         end
         
         it "should return false if there is not someone with the name" do
-          @instance.has_combatant?("Jane").should be false
+          expect(@instance.has_combatant?("Jane")).to be false
         end
       end
       
       describe :find_combatant do
         it "should find combatant is someone with the name" do
-          @instance.find_combatant("Bob").should eq @bob
+          expect(@instance.find_combatant("Bob")).to eq @bob
         end
         
         it "should return nil if there is not someone with the name" do
-          @instance.find_combatant("Jane").should be_nil
+          expect(@instance.find_combatant("Jane")).to be_nil
         end
       end
     end

--- a/plugins/fs3combat/specs/combatant_helper_specs.rb
+++ b/plugins/fs3combat/specs/combatant_helper_specs.rb
@@ -4,202 +4,202 @@ module AresMUSH
       before do
         @combatant = double
         @char = double
-        @combatant.stub(:log)
-        @combatant.stub(:name) { "Trooper" }
-        @combatant.stub(:character) { @char }
-        SpecHelpers.stub_translate_for_testing
+        allow(@combatant).to receive(:log)
+        allow(@combatant).to receive(:name) { "Trooper" }
+        allow(@combatant).to receive(:character) { @char }
+        stub_translate_for_testing
       end
       
       
       describe :roll_attack do
         before do
-          FS3Combat.stub(:weapon_stat).with("Knife", "skill") { "Knives" }
-          FS3Combat.stub(:weapon_stat).with("Knife", "accuracy") { 0 }
-          @combatant.stub(:total_damage_mod) { 0 }
-          @combatant.stub(:attack_stance_mod) { 0 }
-          @combatant.stub(:stress) { 0 }
-          @combatant.stub(:distraction) { 0 }
-          @combatant.stub(:attack_mod) { 0 }
-          @combatant.stub(:is_aiming?) { false }
-          @combatant.stub(:weapon) { "Knife" }
-          @combatant.stub(:luck)
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "skill") { "Knives" }
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "accuracy") { 0 }
+          allow(@combatant).to receive(:total_damage_mod) { 0 }
+          allow(@combatant).to receive(:attack_stance_mod) { 0 }
+          allow(@combatant).to receive(:stress) { 0 }
+          allow(@combatant).to receive(:distraction) { 0 }
+          allow(@combatant).to receive(:attack_mod) { 0 }
+          allow(@combatant).to receive(:is_aiming?) { false }
+          allow(@combatant).to receive(:weapon) { "Knife" }
+          allow(@combatant).to receive(:luck)
           @target = double
-          @target.stub(:mount_type) { nil }
-          @combatant.stub(:mount_type) { nil }
+          allow(@target).to receive(:mount_type) { nil }
+          allow(@combatant).to receive(:mount_type) { nil }
         end
         
         it "should roll the weapon attack stat" do
-          @combatant.should_receive(:roll_ability).with("Knives", 0)
+          expect(@combatant).to receive(:roll_ability).with("Knives", 0)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should account for aim modifier if aimed at the same target" do
-          @combatant.stub(:is_aiming?) { true }
-          @combatant.stub(:aim_target) { @target }
+          allow(@combatant).to receive(:is_aiming?) { true }
+          allow(@combatant).to receive(:aim_target) { @target }
           action = double
-          action.stub(:target) { @target }
-          @combatant.stub(:action) { action }
+          allow(action).to receive(:target) { @target }
+          allow(@combatant).to receive(:action) { action }
           
-          @combatant.should_receive(:roll_ability).with("Knives", 3)
+          expect(@combatant).to receive(:roll_ability).with("Knives", 3)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should not apply aim modifier if aimed at a different target" do
-          @combatant.stub(:is_aiming?) { true }
-          @combatant.stub(:aim_target) { @target }
+          allow(@combatant).to receive(:is_aiming?) { true }
+          allow(@combatant).to receive(:aim_target) { @target }
           action = double
-          action.stub(:target) { double }
-          @combatant.stub(:action) { action }
+          allow(action).to receive(:target) { double }
+          allow(@combatant).to receive(:action) { action }
           
-          @combatant.should_receive(:roll_ability).with("Knives", 0)
+          expect(@combatant).to receive(:roll_ability).with("Knives", 0)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         
         it "should account for wound modifiers" do
-          @combatant.stub(:total_damage_mod) { -1 }
-          @combatant.should_receive(:roll_ability).with("Knives", -1)
+          allow(@combatant).to receive(:total_damage_mod) { -1 }
+          expect(@combatant).to receive(:roll_ability).with("Knives", -1)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should account for distract modifiers" do
-          @combatant.stub(:distraction) { 2 }
-          @combatant.should_receive(:roll_ability).with("Knives", -2)
+          allow(@combatant).to receive(:distraction) { 2 }
+          expect(@combatant).to receive(:roll_ability).with("Knives", -2)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should account for stance modifiers" do
-          @combatant.stub(:attack_stance_mod) { 1 }
-          @combatant.should_receive(:roll_ability).with("Knives", 1)
+          allow(@combatant).to receive(:attack_stance_mod) { 1 }
+          expect(@combatant).to receive(:roll_ability).with("Knives", 1)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should give a bonus when mounted vs unmounted target" do
-          @target.stub(:mount_type) { nil }
-          @combatant.stub(:mount_type) { "Horse" }
-          FS3Combat.stub(:mount_stat).with("Horse", "mod_vs_unmounted") { 2 } 
-          @combatant.should_receive(:roll_ability).with("Knives", 2)
+          allow(@target).to receive(:mount_type) { nil }
+          allow(@combatant).to receive(:mount_type) { "Horse" }
+          allow(FS3Combat).to receive(:mount_stat).with("Horse", "mod_vs_unmounted") { 2 } 
+          expect(@combatant).to receive(:roll_ability).with("Knives", 2)
           FS3Combat.roll_attack(@combatant, @target)
         end
 
         it "should not give a bonus when mounted vs mounted target" do
-          @target.stub(:mount_type) { "Horse" }
-          @combatant.stub(:mount_type) { "War Horse" }
-          @combatant.should_receive(:roll_ability).with("Knives", 0)
+          allow(@target).to receive(:mount_type) { "Horse" }
+          allow(@combatant).to receive(:mount_type) { "War Horse" }
+          expect(@combatant).to receive(:roll_ability).with("Knives", 0)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should give penalty when unmounted vs mounted target" do
-          @target.stub(:mount_type) { "Horse" }
-          FS3Combat.stub(:mount_stat).with("Horse", "mod_vs_unmounted") { 2 } 
-          @combatant.stub(:mount_type) { nil }
-          @combatant.should_receive(:roll_ability).with("Knives", -2)
+          allow(@target).to receive(:mount_type) { "Horse" }
+          allow(FS3Combat).to receive(:mount_stat).with("Horse", "mod_vs_unmounted") { 2 } 
+          allow(@combatant).to receive(:mount_type) { nil }
+          expect(@combatant).to receive(:roll_ability).with("Knives", -2)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should account for accuracy modifiers" do
-          FS3Combat.stub(:weapon_stat).with("Knife", "accuracy") { 2 }
-          @combatant.should_receive(:roll_ability).with("Knives", 2)
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "accuracy") { 2 }
+          expect(@combatant).to receive(:roll_ability).with("Knives", 2)
           FS3Combat.roll_attack(@combatant, @target)
         end
         
         it "should account for stress modifiers" do
-          @combatant.stub(:stress) { 1 }
-          @combatant.should_receive(:roll_ability).with("Knives", -1)
+          allow(@combatant).to receive(:stress) { 1 }
+          expect(@combatant).to receive(:roll_ability).with("Knives", -1)
           FS3Combat.roll_attack(@combatant, @target)
         end
 
         it "should account for luck spent on attack" do
-          @combatant.stub(:luck) { "Attack" }
-          @combatant.should_receive(:roll_ability).with("Knives", 3)
+          allow(@combatant).to receive(:luck) { "Attack" }
+          expect(@combatant).to receive(:roll_ability).with("Knives", 3)
           FS3Combat.roll_attack(@combatant, @target)
         end
 
         it "should ignore luck spent on something else" do
-          @combatant.stub(:luck) { "Defense" }
-          @combatant.should_receive(:roll_ability).with("Knives", 0)
+          allow(@combatant).to receive(:luck) { "Defense" }
+          expect(@combatant).to receive(:roll_ability).with("Knives", 0)
           FS3Combat.roll_attack(@combatant, @target)
         end
                 
         it "should account for passed-in modifiers" do
-          @combatant.should_receive(:roll_ability).with("Knives", -2)
+          expect(@combatant).to receive(:roll_ability).with("Knives", -2)
           FS3Combat.roll_attack(@combatant, @target, -2)
         end
         
         it "should account for multiple modifiers" do
-          @combatant.stub(:total_damage_mod) { -2 }
-          @combatant.stub(:attack_stance_mod) { 1 }
-          FS3Combat.stub(:weapon_stat).with("Knife", "accuracy") { 2 }
-          @combatant.should_receive(:roll_ability).with("Knives", 2)
+          allow(@combatant).to receive(:total_damage_mod) { -2 }
+          allow(@combatant).to receive(:attack_stance_mod) { 1 }
+          allow(FS3Combat).to receive(:weapon_stat).with("Knife", "accuracy") { 2 }
+          expect(@combatant).to receive(:roll_ability).with("Knives", 2)
           FS3Combat.roll_attack(@combatant, @target, 1)
         end
       end
       
       describe :roll_defense do
         before do
-          @combatant.stub(:total_damage_mod) { 0 }
-          @combatant.stub(:defense_stance_mod) { 0 }
-          @combatant.stub(:defense_mod) { 0 }
-          @combatant.stub(:distraction) { 0 }
-          @combatant.stub(:luck)
-          @combatant.stub(:armor) { "armor" }
-          FS3Combat.stub(:weapon_defense_skill) { "Reaction" }
-          FS3Combat.stub(:vehicle_dodge_mod) { 0 }
-          FS3Combat.stub(:armor_stat) { 0 }
+          allow(@combatant).to receive(:total_damage_mod) { 0 }
+          allow(@combatant).to receive(:defense_stance_mod) { 0 }
+          allow(@combatant).to receive(:defense_mod) { 0 }
+          allow(@combatant).to receive(:distraction) { 0 }
+          allow(@combatant).to receive(:luck)
+          allow(@combatant).to receive(:armor) { "armor" }
+          allow(FS3Combat).to receive(:weapon_defense_skill) { "Reaction" }
+          allow(FS3Combat).to receive(:vehicle_dodge_mod) { 0 }
+          allow(FS3Combat).to receive(:armor_stat) { 0 }
         end
         
         it "should roll the weapon defense stat" do
-          FS3Combat.should_receive(:weapon_defense_skill).with(@combatant, "Knife") { "Reaction" }
-          @combatant.should_receive(:roll_ability).with("Reaction", 0)
+          expect(FS3Combat).to receive(:weapon_defense_skill).with(@combatant, "Knife") { "Reaction" }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", 0)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
         
         it "should account for wound modifiers" do
-          @combatant.stub(:total_damage_mod) { -1 }
-          @combatant.should_receive(:roll_ability).with("Reaction", -1)
+          allow(@combatant).to receive(:total_damage_mod) { -1 }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", -1)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
         
         it "should account for distract modifiers" do
-          @combatant.stub(:distraction) { 2 }
-          @combatant.should_receive(:roll_ability).with("Reaction", -2)
+          allow(@combatant).to receive(:distraction) { 2 }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", -2)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
                 
         it "should account for stance modifiers" do
-          @combatant.stub(:defense_stance_mod) { 1 }
-          @combatant.should_receive(:roll_ability).with("Reaction", 1)
+          allow(@combatant).to receive(:defense_stance_mod) { 1 }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", 1)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
         
         it "should account for vehicle dodge modifiers" do
-          FS3Combat.should_receive(:vehicle_dodge_mod).with(@combatant) { 1 }
-          @combatant.should_receive(:roll_ability).with("Reaction", 1)
+          expect(FS3Combat).to receive(:vehicle_dodge_mod).with(@combatant) { 1 }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", 1)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
         
         it "should account for luck spent on defense" do
-          @combatant.stub(:luck) { "Defense" }
-          @combatant.should_receive(:roll_ability).with("Reaction", 3)
+          allow(@combatant).to receive(:luck) { "Defense" }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", 3)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
 
         it "should ignore luck spent on something else" do
-          @combatant.stub(:luck) { "Attack" }
-          @combatant.should_receive(:roll_ability).with("Reaction", 0)
+          allow(@combatant).to receive(:luck) { "Attack" }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", 0)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
 
         it "should account for armor defense stat" do
-          FS3Combat.should_receive(:armor_stat).with("armor", "defense") { 1 }
-          @combatant.should_receive(:roll_ability).with("Reaction", 1)
+          expect(FS3Combat).to receive(:armor_stat).with("armor", "defense") { 1 }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", 1)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
         
         it "should account for multiple modifiers" do
-          @combatant.stub(:total_damage_mod) { -2 }
-          @combatant.stub(:defense_stance_mod) { 1 }
-          @combatant.should_receive(:roll_ability).with("Reaction", -1)
+          allow(@combatant).to receive(:total_damage_mod) { -2 }
+          allow(@combatant).to receive(:defense_stance_mod) { 1 }
+          expect(@combatant).to receive(:roll_ability).with("Reaction", -1)
           FS3Combat.roll_defense(@combatant, "Knife")
         end
       end
@@ -208,48 +208,48 @@ module AresMUSH
       describe :weapon_defense_skill do
         describe "soldiers" do
           before do
-            FS3Combat.stub(:weapon_stat).with("Sword", "weapon_type") { "Melee" }
-            FS3Combat.stub(:weapon_stat).with("Sword", "skill") { "Swords" }
-            FS3Combat.stub(:weapon_stat).with("Knife", "weapon_type") { "Melee" }
-            FS3Combat.stub(:weapon_stat).with("Knife", "skill") { "Knives" }
-            FS3Combat.stub(:weapon_stat).with("Pistol", "weapon_type") { "Ranged" }
-            FS3Combat.stub(:weapon_stat).with("Pistol", "skill") { "Firearms" }
-            FS3Combat.stub(:combatant_type_stat).with("Soldier", "defense_skill") { "Reaction" }
-            @combatant.stub(:combatant_type) { "Soldier" }
-            @combatant.stub(:is_in_vehicle?) { false }
+            allow(FS3Combat).to receive(:weapon_stat).with("Sword", "weapon_type") { "Melee" }
+            allow(FS3Combat).to receive(:weapon_stat).with("Sword", "skill") { "Swords" }
+            allow(FS3Combat).to receive(:weapon_stat).with("Knife", "weapon_type") { "Melee" }
+            allow(FS3Combat).to receive(:weapon_stat).with("Knife", "skill") { "Knives" }
+            allow(FS3Combat).to receive(:weapon_stat).with("Pistol", "weapon_type") { "Ranged" }
+            allow(FS3Combat).to receive(:weapon_stat).with("Pistol", "skill") { "Firearms" }
+            allow(FS3Combat).to receive(:combatant_type_stat).with("Soldier", "defense_skill") { "Reaction" }
+            allow(@combatant).to receive(:combatant_type) { "Soldier" }
+            allow(@combatant).to receive(:is_in_vehicle?) { false }
           end
         
           it "should use defender melee skill for melee vs melee" do
-            @combatant.stub(:weapon) { "Knife" }
-            FS3Combat.weapon_defense_skill(@combatant, "Sword").should eq "Knives"
+            allow(@combatant).to receive(:weapon) { "Knife" }
+            expect(FS3Combat.weapon_defense_skill(@combatant, "Sword")).to eq "Knives"
           end
         
           it "should use defender type default for melee vs ranged" do
-            @combatant.stub(:weapon) { "Pistol" }
-            FS3Combat.weapon_defense_skill(@combatant, "Sword").should eq "Reaction"
+            allow(@combatant).to receive(:weapon) { "Pistol" }
+            expect(FS3Combat.weapon_defense_skill(@combatant, "Sword")).to eq "Reaction"
           end
           
           it "should use defender type default for ranged vs melee" do
-            @combatant.stub(:weapon) { "Knife" }
-            FS3Combat.weapon_defense_skill(@combatant, "Pistol").should eq "Reaction"
+            allow(@combatant).to receive(:weapon) { "Knife" }
+            expect(FS3Combat.weapon_defense_skill(@combatant, "Pistol")).to eq "Reaction"
           end
           
           
           it "should use the global default if no defender type specified" do
-            @combatant.stub(:combatant_type) { "NoDefense" }
-            FS3Combat.stub(:combatant_type_stat).with("NoDefense", "defense_skill") { nil }
-            Global.stub(:read_config).with("fs3combat", "default_defense_skill") { "Other" }
-            @combatant.stub(:weapon) { "Pistol" }
-            FS3Combat.weapon_defense_skill(@combatant, "Sword").should eq "Other"
+            allow(@combatant).to receive(:combatant_type) { "NoDefense" }
+            allow(FS3Combat).to receive(:combatant_type_stat).with("NoDefense", "defense_skill") { nil }
+            allow(Global).to receive(:read_config).with("fs3combat", "default_defense_skill") { "Other" }
+            allow(@combatant).to receive(:weapon) { "Pistol" }
+            expect(FS3Combat.weapon_defense_skill(@combatant, "Sword")).to eq "Other"
           end
           
           it "should use piloting skill if in a vehicle" do
             vehicle = double
-            @combatant.stub(:is_in_vehicle?) { true }
-            @combatant.stub(:vehicle) { vehicle }
-            vehicle.stub(:vehicle_type) { "Viper" }
-            FS3Combat.stub(:vehicle_stat).with("Viper", "pilot_skill") { "Piloting" }
-            FS3Combat.weapon_defense_skill(@combatant, "Pistol").should eq "Piloting"
+            allow(@combatant).to receive(:is_in_vehicle?) { true }
+            allow(@combatant).to receive(:vehicle) { vehicle }
+            allow(vehicle).to receive(:vehicle_type) { "Viper" }
+            allow(FS3Combat).to receive(:vehicle_stat).with("Viper", "pilot_skill") { "Piloting" }
+            expect(FS3Combat.weapon_defense_skill(@combatant, "Pistol")).to eq "Piloting"
           end
         end            
         
@@ -258,219 +258,219 @@ module AresMUSH
       describe :hitloc_chart do
         before do 
           @vehicle = double
-          @combatant.stub(:combatant_type) { "soldier" }
-          @combatant.stub(:vehicle) { nil }
+          allow(@combatant).to receive(:combatant_type) { "soldier" }
+          allow(@combatant).to receive(:vehicle) { nil }
           @hitloc = { "areas" => "x" }
         end
           
         it "should use a soldier's hitloc chart" do
-          FS3Combat.should_receive(:combatant_type_stat).with("soldier", "hitloc") { "human" }
-          FS3Combat.should_receive(:hitloc_chart_for_type).with("human") { @hitloc }
-          FS3Combat.hitloc_chart(@combatant).should eq @hitloc
+          expect(FS3Combat).to receive(:combatant_type_stat).with("soldier", "hitloc") { "human" }
+          expect(FS3Combat).to receive(:hitloc_chart_for_type).with("human") { @hitloc }
+          expect(FS3Combat.hitloc_chart(@combatant)).to eq @hitloc
         end
         
         it "should use a pilot's vehicle's hitloc chart if not a crew hit" do
-          @combatant.stub(:vehicle) { @vehicle }
-          @vehicle.stub(:hitloc_type) { "fighter" }
-          FS3Combat.should_receive(:hitloc_chart_for_type).with("fighter") { @hitloc }
-          FS3Combat.hitloc_chart(@combatant).should eq @hitloc
+          allow(@combatant).to receive(:vehicle) { @vehicle }
+          allow(@vehicle).to receive(:hitloc_type) { "fighter" }
+          expect(FS3Combat).to receive(:hitloc_chart_for_type).with("fighter") { @hitloc }
+          expect(FS3Combat.hitloc_chart(@combatant)).to eq @hitloc
         end
         
         it "should use the pilot's hitloc chart if a crew hit" do
-          @combatant.stub(:vehicle) { @vehicle }
-          FS3Combat.should_receive(:combatant_type_stat).with("soldier", "hitloc") { "human" }
-          FS3Combat.should_receive(:hitloc_chart_for_type).with("human") { @hitloc }
-          FS3Combat.hitloc_chart(@combatant, true).should eq @hitloc
+          allow(@combatant).to receive(:vehicle) { @vehicle }
+          expect(FS3Combat).to receive(:combatant_type_stat).with("soldier", "hitloc") { "human" }
+          expect(FS3Combat).to receive(:hitloc_chart_for_type).with("human") { @hitloc }
+          expect(FS3Combat.hitloc_chart(@combatant, true)).to eq @hitloc
         end
       end
       
       describe :hitloc_areas do
         it "should extract areas from the hitloc chart" do
-          FS3Combat.should_receive(:hitloc_chart).with(@combatant, true) { { "areas" => "x" } }
-          FS3Combat.hitloc_areas(@combatant, true).should eq "x"
+          expect(FS3Combat).to receive(:hitloc_chart).with(@combatant, true) { { "areas" => "x" } }
+          expect(FS3Combat.hitloc_areas(@combatant, true)).to eq "x"
         end
       end
     
       describe :hitloc_severity do
         before do 
-          FS3Combat.stub(:hitloc_chart).with(@combatant, false) { 
+          allow(FS3Combat).to receive(:hitloc_chart).with(@combatant, false) { 
             { "vital_areas" => [ "Abdomen" ], 
               "critical_areas" => ["head"] }}
             
-          @combatant.stub(:combatant_type) { "soldier"}
+          allow(@combatant).to receive(:combatant_type) { "soldier"}
         end
         
         it "should determine severity for a critical area" do
-          FS3Combat.hitloc_severity(@combatant, "Head").should eq "Critical"
+          expect(FS3Combat.hitloc_severity(@combatant, "Head")).to eq "Critical"
         end
 
         it "should determine severity for a vital area" do
-          FS3Combat.hitloc_severity(@combatant, "ABDOMEN").should eq "Vital"
+          expect(FS3Combat.hitloc_severity(@combatant, "ABDOMEN")).to eq "Vital"
         end
 
         it "should determine severity for a regular area" do
-          FS3Combat.hitloc_severity(@combatant, "Arm").should eq "Normal"
+          expect(FS3Combat.hitloc_severity(@combatant, "Arm")).to eq "Normal"
         end
       end
       
       describe :determine_hitloc do 
         before do 
-          FS3Combat.stub(:hitloc_areas) { {
+          allow(FS3Combat).to receive(:hitloc_areas) { {
             "Chest" => [ "A", "B", "C" ],
             "Head" => [ "D", "E", "F", "G" ]
           }}
         end
         
         it "should work with random lowest value" do
-          FS3Combat.should_receive(:rand).with(3) { 0 }
-          FS3Combat.determine_hitloc(@combatant, 0).should eq "A"
+          expect(FS3Combat).to receive(:rand).with(3) { 0 }
+          expect(FS3Combat.determine_hitloc(@combatant, 0)).to eq "A"
         end
         
         it "should work with random highest value" do
-          FS3Combat.should_receive(:rand).with(3) { 2 }
-          FS3Combat.determine_hitloc(@combatant, 0).should eq "C"
+          expect(FS3Combat).to receive(:rand).with(3) { 2 }
+          expect(FS3Combat.determine_hitloc(@combatant, 0)).to eq "C"
         end
         
         it "should add in successes with lowest random value" do
-          FS3Combat.should_receive(:rand).with(3) { 0 }
-          FS3Combat.determine_hitloc(@combatant, 1).should eq "B"
+          expect(FS3Combat).to receive(:rand).with(3) { 0 }
+          expect(FS3Combat.determine_hitloc(@combatant, 1)).to eq "B"
         end
         
         it "should add in successes with highest random value" do
-          FS3Combat.should_receive(:rand).with(3) { 2 }
-          FS3Combat.determine_hitloc(@combatant, 1).should eq "C"
+          expect(FS3Combat).to receive(:rand).with(3) { 2 }
+          expect(FS3Combat.determine_hitloc(@combatant, 1)).to eq "C"
         end
         
         it "should work with lowest value and negative modifier" do
-          FS3Combat.should_receive(:rand).with(3) { 0 }
-          FS3Combat.determine_hitloc(@combatant, -2).should eq "A"
+          expect(FS3Combat).to receive(:rand).with(3) { 0 }
+          expect(FS3Combat.determine_hitloc(@combatant, -2)).to eq "A"
         end
         
         it "should return the exact hit location if called shot and net >= 3" do
-          FS3Combat.determine_hitloc(@combatant, 3, "Head").should eq "Head"
+          expect(FS3Combat.determine_hitloc(@combatant, 3, "Head")).to eq "Head"
         end
         
         it "should use the called shot hitloc chart if called shot and net < 3" do
-          FS3Combat.should_receive(:rand).with(4) { 0 }
-          FS3Combat.determine_hitloc(@combatant, 2, "Head").should eq "F"
+          expect(FS3Combat).to receive(:rand).with(4) { 0 }
+          expect(FS3Combat.determine_hitloc(@combatant, 2, "Head")).to eq "F"
         end
       end
       
       describe :roll_initiative do
         before do
-          @combatant.stub(:roll_ability) { 2 }
-          @combatant.stub(:total_damage_mod) { 0 } 
-          @combatant.stub(:luck)
-          @combatant.stub(:action_klass) { "" }
-          @combatant.stub(:weapon) { "" }
-          FS3Combat.stub(:weapon_stat) { 0 }
+          allow(@combatant).to receive(:roll_ability) { 2 }
+          allow(@combatant).to receive(:total_damage_mod) { 0 } 
+          allow(@combatant).to receive(:luck)
+          allow(@combatant).to receive(:action_klass) { "" }
+          allow(@combatant).to receive(:weapon) { "" }
+          allow(FS3Combat).to receive(:weapon_stat) { 0 }
         end
         
         it "should roll the init ability" do
-          @combatant.should_receive(:roll_ability).with("init", 0) { 3 }
-          FS3Combat.roll_initiative(@combatant, "init").should eq 3
+          expect(@combatant).to receive(:roll_ability).with("init", 0) { 3 }
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 3
         end
         
         it "should subtract damage modifiers" do
-          @combatant.should_receive(:roll_ability).with("init", -1) { 3 }
-          @combatant.stub(:total_damage_mod) { -1 } 
-          FS3Combat.roll_initiative(@combatant, "init").should eq 3
+          expect(@combatant).to receive(:roll_ability).with("init", -1) { 3 }
+          allow(@combatant).to receive(:total_damage_mod) { -1 } 
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 3
         end
         
         it "should account for luck spent on initiative" do
-          @combatant.stub(:luck) {"Initiative"}
-          @combatant.should_receive(:roll_ability).with("init", 3) { 3 }
-          FS3Combat.roll_initiative(@combatant, "init").should eq 3
+          allow(@combatant).to receive(:luck) {"Initiative"}
+          expect(@combatant).to receive(:roll_ability).with("init", 3) { 3 }
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 3
         end
 
         it "should ignore luck spent on something else" do
-          @combatant.stub(:luck) {"Attack"}
-          @combatant.should_receive(:roll_ability).with("init", 0) { 1 }
-          FS3Combat.roll_initiative(@combatant, "init").should eq 1
+          allow(@combatant).to receive(:luck) {"Attack"}
+          expect(@combatant).to receive(:roll_ability).with("init", 0) { 1 }
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 1
         end
         
         it "should add in a weapon modifier" do 
-          @combatant.stub(:weapon) { "Rapier" }
-          FS3Combat.should_receive(:weapon_stat).with("Rapier", "init_mod") { 2 }
-          @combatant.should_receive(:roll_ability).with("init", 2) { 3 }
-          FS3Combat.roll_initiative(@combatant, "init").should eq 3
+          allow(@combatant).to receive(:weapon) { "Rapier" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rapier", "init_mod") { 2 }
+          expect(@combatant).to receive(:roll_ability).with("init", 2) { 3 }
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 3
         end
         
         it "should default to 0 for weapon mod" do
-          @combatant.stub(:weapon) { "Rapier" }
-          FS3Combat.should_receive(:weapon_stat).with("Rapier", "init_mod") { nil }
-          @combatant.should_receive(:roll_ability).with("init", 0) { 1 }
-          FS3Combat.roll_initiative(@combatant, "init").should eq 1
+          allow(@combatant).to receive(:weapon) { "Rapier" }
+          expect(FS3Combat).to receive(:weapon_stat).with("Rapier", "init_mod") { nil }
+          expect(@combatant).to receive(:roll_ability).with("init", 0) { 1 }
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 1
         end
 
         it "should apply mod for subdue action" do
-          @combatant.stub(:action_klass) { "AresMUSH::FS3Combat::SubdueAction" }
-          @combatant.should_receive(:roll_ability).with("init", 3) { 4 }                  
-          FS3Combat.roll_initiative(@combatant, "init").should eq 4
+          allow(@combatant).to receive(:action_klass) { "AresMUSH::FS3Combat::SubdueAction" }
+          expect(@combatant).to receive(:roll_ability).with("init", 3) { 4 }                  
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 4
         end
                 
         it "should apply mod for suppress action" do
-          @combatant.stub(:action_klass) { "AresMUSH::FS3Combat::SuppressAction" }
-          @combatant.should_receive(:roll_ability).with("init", 3) { 4 }                  
-          FS3Combat.roll_initiative(@combatant, "init").should eq 4
+          allow(@combatant).to receive(:action_klass) { "AresMUSH::FS3Combat::SuppressAction" }
+          expect(@combatant).to receive(:roll_ability).with("init", 3) { 4 }                  
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 4
         end
         
         it "should apply mod for distract action" do
-          @combatant.stub(:action_klass) { "AresMUSH::FS3Combat::DistractAction" }
-          @combatant.should_receive(:roll_ability).with("init", 3) { 4 }
-          FS3Combat.roll_initiative(@combatant, "init").should eq 4
+          allow(@combatant).to receive(:action_klass) { "AresMUSH::FS3Combat::DistractAction" }
+          expect(@combatant).to receive(:roll_ability).with("init", 3) { 4 }
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 4
         end
         
         it "should not apply mod for regular actions" do
-          @combatant.stub(:action_klass) { "AresMUSH::FS3Combat::AttackAction" }
-          @combatant.should_receive(:roll_ability).with("init", 0) { 2 }
-          FS3Combat.roll_initiative(@combatant, "init").should eq 2
+          allow(@combatant).to receive(:action_klass) { "AresMUSH::FS3Combat::AttackAction" }
+          expect(@combatant).to receive(:roll_ability).with("init", 0) { 2 }
+          expect(FS3Combat.roll_initiative(@combatant, "init")).to eq 2
         end
       end
       
       describe :check_ammo do
         before do
-          @combatant.stub(:max_ammo) { 10 }
+          allow(@combatant).to receive(:max_ammo) { 10 }
         end
         
         it "should return true if the weapon doesn't use ammo" do
-          @combatant.stub(:max_ammo) { 0 }
-          FS3Combat.check_ammo(@combatant, 22).should be true          
+          allow(@combatant).to receive(:max_ammo) { 0 }
+          expect(FS3Combat.check_ammo(@combatant, 22)).to be true          
         end
          
         it "should return true if enough bullets" do
-          @combatant.stub(:ammo) { 10 }
-          FS3Combat.check_ammo(@combatant, 2).should be true
+          allow(@combatant).to receive(:ammo) { 10 }
+          expect(FS3Combat.check_ammo(@combatant, 2)).to be true
         end
         
         it "should return false if not enough bullets" do
-          @combatant.stub(:ammo) { 10 }
-          FS3Combat.check_ammo(@combatant, 22).should be false
+          allow(@combatant).to receive(:ammo) { 10 }
+          expect(FS3Combat.check_ammo(@combatant, 22)).to be false
         end
       end
         
       
       describe :update_ammo do
         before do
-          @combatant.stub(:max_ammo) { 10 }
+          allow(@combatant).to receive(:max_ammo) { 10 }
         end
           
         it "should not do anything if the weapon doesn't use ammo" do
-          @combatant.stub(:max_ammo) { 0 }
-          @combatant.should_not_receive(:update)
-          FS3Combat.update_ammo(@combatant, 1).should be_nil
+          allow(@combatant).to receive(:max_ammo) { 0 }
+          expect(@combatant).to_not receive(:update)
+          expect(FS3Combat.update_ammo(@combatant, 1)).to be_nil
         end
       
         it "should adjust ammo by the number of bullets" do
-          @combatant.stub(:ammo) { 15 }
-          @combatant.should_receive(:update).with(ammo: 12)
-          FS3Combat.update_ammo(@combatant, 3).should be_nil
+          allow(@combatant).to receive(:ammo) { 15 }
+          expect(@combatant).to receive(:update).with(ammo: 12)
+          expect(FS3Combat.update_ammo(@combatant, 3)).to be_nil
         end
       
         it "should warn if out of ammo" do
-          @combatant.stub(:ammo) { 4 }
-          @combatant.should_receive(:update).with(ammo: 0)
-          FS3Combat.update_ammo(@combatant, 4).should eq "fs3combat.weapon_clicks_empty"
+          allow(@combatant).to receive(:ammo) { 4 }
+          expect(@combatant).to receive(:update).with(ammo: 0)
+          expect(FS3Combat.update_ammo(@combatant, 4)).to eq "fs3combat.weapon_clicks_empty"
         end
       end
     end

--- a/plugins/fs3combat/specs/damage_helper_specs.rb
+++ b/plugins/fs3combat/specs/damage_helper_specs.rb
@@ -3,20 +3,20 @@ module AresMUSH
     describe FS3Combat do
       
       before do
-        Global.stub(:read_config).with("fs3combat", "recovery_skill") { "Body" }
-        Global.stub(:read_config).with("fs3combat", "treat_skill") { "First Aid" }
-        SpecHelpers.stub_translate_for_testing        
+        allow(Global).to receive(:read_config).with("fs3combat", "recovery_skill") { "Body" }
+        allow(Global).to receive(:read_config).with("fs3combat", "treat_skill") { "First Aid" }
+        stub_translate_for_testing        
       end
         
       describe :print_damage do
         it "should print the right damage" do
-          FS3Combat.print_damage(-0).should eq "%xr%xn----"
-          FS3Combat.print_damage(-0.25).should eq "%xrX%xn---"
-          FS3Combat.print_damage(-1.0).should eq "%xrX%xn---"
-          FS3Combat.print_damage(-1.25).should eq "%xrXX%xn--"
-          FS3Combat.print_damage(-2.25).should eq "%xrXXX%xn-"
-          FS3Combat.print_damage(-3.25).should eq "%xrXXXX%xn"
-          FS3Combat.print_damage(-5).should eq "%xrXXXX%xn"
+          expect(FS3Combat.print_damage(-0)).to eq "%xr%xn----"
+          expect(FS3Combat.print_damage(-0.25)).to eq "%xrX%xn---"
+          expect(FS3Combat.print_damage(-1.0)).to eq "%xrX%xn---"
+          expect(FS3Combat.print_damage(-1.25)).to eq "%xrXX%xn--"
+          expect(FS3Combat.print_damage(-2.25)).to eq "%xrXXX%xn-"
+          expect(FS3Combat.print_damage(-3.25)).to eq "%xrXXXX%xn"
+          expect(FS3Combat.print_damage(-5)).to eq "%xrXXXX%xn"
         end
       end
       
@@ -24,78 +24,78 @@ module AresMUSH
         it "should count all wound levels" do
           damage1 = double
           damage2 = double
-          damage1.stub(:wound_mod) { 1 }
-          damage2.stub(:wound_mod) { 2 }
+          allow(damage1).to receive(:wound_mod) { 1 }
+          allow(damage2).to receive(:wound_mod) { 2 }
           wounds = [ damage1, damage2 ]
           char = double
-          char.stub(:damage) { wounds }
-          FS3Combat.total_damage_mod(char).should eq -3
+          allow(char).to receive(:damage) { wounds }
+          expect(FS3Combat.total_damage_mod(char)).to eq -3
         end
 
         it "should count empty damage" do
           char = double
-          char.stub(:damage) { [] }
-          FS3Combat.total_damage_mod(char).should eq 0
+          allow(char).to receive(:damage) { [] }
+          expect(FS3Combat.total_damage_mod(char)).to eq 0
         end        
       end
       
       describe :heal_wounds do
         before do
           @char = double
-          @char.stub(:name) { "Bob" }
+          allow(@char).to receive(:name) { "Bob" }
           @damage1 = double
           @damage2 = double
-          @damage1.stub(:healing_points) { 2 }
-          @damage2.stub(:healing_points) { 2 }
+          allow(@damage1).to receive(:healing_points) { 2 }
+          allow(@damage2).to receive(:healing_points) { 2 }
           @wounds =  [@damage1, @damage2]
-          FS3Combat.stub(:is_in_hospital?) { false }
-          @char.stub(:doctors) { [] }
-          @char.stub(:damage) { @wounds }
-          FS3Skills.stub(:one_shot_roll) { { :successes => 0 } }
+          allow(FS3Combat).to receive(:is_in_hospital?) { false }
+          allow(@char).to receive(:doctors) { [] }
+          allow(@char).to receive(:damage) { @wounds }
+          allow(FS3Skills).to receive(:one_shot_roll) { { :successes => 0 } }
         end
         
         it "should apply a base of 1 healing point to each wound" do
-          FS3Combat.should_receive(:heal).with(@damage1, 1)
-          FS3Combat.should_receive(:heal).with(@damage2, 1)
+          expect(FS3Combat).to receive(:heal).with(@damage1, 1)
+          expect(FS3Combat).to receive(:heal).with(@damage2, 1)
           FS3Combat.heal_wounds(@char)
         end
         
         it "should add a recovery roll to the healing points" do
-          FS3Skills.should_receive(:one_shot_roll) do |client, char, roll_params|
-            client.should be_nil
-            char.should eq @char
-            roll_params.ability.should eq "Body"
+          expect(FS3Skills).to receive(:one_shot_roll) do |client, char, roll_params|
+            expect(client).to be_nil
+            expect(char).to eq @char
+            expect(roll_params.ability).to eq "Body"
             { :successes => 4 }
           end
-          FS3Combat.should_receive(:heal).with(@damage1, 2)
-          FS3Combat.should_receive(:heal).with(@damage2, 2)
+          expect(FS3Combat).to receive(:heal).with(@damage1, 2)
+          expect(FS3Combat).to receive(:heal).with(@damage2, 2)
           FS3Combat.heal_wounds(@char)
         end
         
         it "should add 1 if in hospital" do
-          FS3Combat.stub(:is_in_hospital?) { true }
-          FS3Combat.should_receive(:heal).with(@damage1, 2)
-          FS3Combat.should_receive(:heal).with(@damage2, 2)
+          allow(FS3Combat).to receive(:is_in_hospital?) { true }
+          expect(FS3Combat).to receive(:heal).with(@damage1, 2)
+          expect(FS3Combat).to receive(:heal).with(@damage2, 2)
           FS3Combat.heal_wounds(@char)
         end
 
         it "should add 1 if under doctor's care" do
           doctor = double
-          doctor.stub(:name) { "Dr. Carter" }
-          @char.stub(:doctors) { [doctor] }
-          FS3Combat.should_receive(:heal).with(@damage1, 2)
-          FS3Combat.should_receive(:heal).with(@damage2, 2)
+          allow(doctor).to receive(:name) { "Dr. Carter" }
+          allow(@char).to receive(:doctors) { [doctor] }
+          expect(FS3Combat).to receive(:heal).with(@damage1, 2)
+          expect(FS3Combat).to receive(:heal).with(@damage2, 2)
           FS3Combat.heal_wounds(@char)
         end
         
         it "should only add 1 if under both doctor and hospital" do
           doctor = double
-          doctor.stub(:name) { "Dr. Carter" }
-          FS3Combat.stub(:is_in_hospital?) { true }
-          @char.stub(:doctors) { [doctor] }
-          FS3Skills.stub(:one_shot_roll) { { :successes => 3 } }
-          FS3Combat.should_receive(:heal).with(@damage1, 2)
-          FS3Combat.should_receive(:heal).with(@damage2, 2)
+          allow(doctor).to receive(:name) { "Dr. Carter" }
+          allow(FS3Combat).to receive(:is_in_hospital?) { true }
+          allow(@char).to receive(:doctors) { [doctor] }
+          allow(FS3Skills).to receive(:one_shot_roll) { { :successes => 3 } }
+          expect(FS3Combat).to receive(:heal).with(@damage1, 2)
+          expect(FS3Combat).to receive(:heal).with(@damage2, 2)
           FS3Combat.heal_wounds(@char)
         end
       end
@@ -103,50 +103,50 @@ module AresMUSH
       
       describe :heal do
         before do
-          Global.stub(:read_config).with("fs3combat", "healing_points", "FLESH") { 5 }
-          Global.stub(:read_config).with("fs3combat", "healing_points", "HEAL") { 0 }
+          allow(Global).to receive(:read_config).with("fs3combat", "healing_points", "FLESH") { 5 }
+          allow(Global).to receive(:read_config).with("fs3combat", "healing_points", "HEAL") { 0 }
           @damage = double
-          @damage.stub(:is_stun) { false }
-          @damage.stub(:save)
+          allow(@damage).to receive(:is_stun) { false }
+          allow(@damage).to receive(:save)
         end
         
         it "should not touch a healed wound" do
-          @damage.stub(:healing_points) { 0 }
-          @damage.should_not_receive(:save)
+          allow(@damage).to receive(:healing_points) { 0 }
+          expect(@damage).to_not receive(:save)
           FS3Combat.heal(@damage, 1)
         end
         
         it "should subtract healing points" do
-          @damage.stub(:healing_points) { 5 }
-          @damage.should_receive(:update).with(healing_points: 3)
-          @damage.should_receive(:update).with(healed: true)
+          allow(@damage).to receive(:healing_points) { 5 }
+          expect(@damage).to receive(:update).with(healing_points: 3)
+          expect(@damage).to receive(:update).with(healed: true)
           FS3Combat.heal(@damage, 2)          
         end
         
         it "should heal stun wounds overnight" do
-          @damage.stub(:healing_points) { 8 }
-          @damage.stub(:is_stun) { true }
-          @damage.should_receive(:update).with(healing_points: 0)
-          @damage.should_receive(:update).with(healed: true)
-          @damage.should_receive(:update).with(current_severity: "HEAL")
+          allow(@damage).to receive(:healing_points) { 8 }
+          allow(@damage).to receive(:is_stun) { true }
+          expect(@damage).to receive(:update).with(healing_points: 0)
+          expect(@damage).to receive(:update).with(healed: true)
+          expect(@damage).to receive(:update).with(current_severity: "HEAL")
           FS3Combat.heal(@damage, 2)          
         end
         
         it "should lower severity and reset points when a wound gets enough healing points" do
-          @damage.stub(:healing_points) { 2 }
-          @damage.stub(:current_severity) { "IMPAIR" }
-          @damage.should_receive(:update).with(healing_points: 5)
-          @damage.should_receive(:update).with(healed: true)
-          @damage.should_receive(:update).with(current_severity: "FLESH")
+          allow(@damage).to receive(:healing_points) { 2 }
+          allow(@damage).to receive(:current_severity) { "IMPAIR" }
+          expect(@damage).to receive(:update).with(healing_points: 5)
+          expect(@damage).to receive(:update).with(healed: true)
+          expect(@damage).to receive(:update).with(current_severity: "FLESH")
           FS3Combat.heal(@damage, 2)  
         end
         
         it "should reset healing points for a healed wound" do
-          @damage.stub(:healing_points) { 2 }
-          @damage.stub(:current_severity) { "FLESH" }
-          @damage.should_receive(:update).with(healing_points: 0)
-          @damage.should_receive(:update).with(healed: true)
-          @damage.should_receive(:update).with(current_severity: "HEAL")
+          allow(@damage).to receive(:healing_points) { 2 }
+          allow(@damage).to receive(:current_severity) { "FLESH" }
+          expect(@damage).to receive(:update).with(healing_points: 0)
+          expect(@damage).to receive(:update).with(healed: true)
+          expect(@damage).to receive(:update).with(current_severity: "HEAL")
           FS3Combat.heal(@damage, 3)  
         end
       end
@@ -158,32 +158,32 @@ module AresMUSH
           @damage2 = double
           @damage3 = double
           
-          @damage1.stub(:current_severity) { "FLESH" }
-          @damage2.stub(:current_severity) { "INCAP" }
-          @damage3.stub(:current_severity) { "IMPAIR" }
+          allow(@damage1).to receive(:current_severity) { "FLESH" }
+          allow(@damage2).to receive(:current_severity) { "INCAP" }
+          allow(@damage3).to receive(:current_severity) { "IMPAIR" }
           
-          @damage1.stub(:is_treatable?) { true }
-          @damage2.stub(:is_treatable?) { true }
-          @damage3.stub(:is_treatable?) { true }
+          allow(@damage1).to receive(:is_treatable?) { true }
+          allow(@damage2).to receive(:is_treatable?) { true }
+          allow(@damage3).to receive(:is_treatable?) { true }
         end
         
         it "should return the most serious wound if all treatable" do          
-          @char.stub(:damage) { [@damage1, @damage2, @damage3] }
-          FS3Combat.worst_treatable_wound(@char).should eq @damage2
+          allow(@char).to receive(:damage) { [@damage1, @damage2, @damage3] }
+          expect(FS3Combat.worst_treatable_wound(@char)).to eq @damage2
         end
         
         it "should ignore treated wounds" do
-          @damage2.stub(:is_treatable?) { false }
-          @char.stub(:damage) { [@damage1, @damage2, @damage3] }
-          FS3Combat.worst_treatable_wound(@char).should eq @damage3
+          allow(@damage2).to receive(:is_treatable?) { false }
+          allow(@char).to receive(:damage) { [@damage1, @damage2, @damage3] }
+          expect(FS3Combat.worst_treatable_wound(@char)).to eq @damage3
         end
         
         it "should return nil if no treatable wounds" do
-          @damage1.stub(:is_treatable?) { false }
-          @damage2.stub(:is_treatable?) { false }
-          @damage3.stub(:is_treatable?) { false }
-          @char.stub(:damage) { [@damage1, @damage2, @damage3] }
-          FS3Combat.worst_treatable_wound(@char).should be_nil
+          allow(@damage1).to receive(:is_treatable?) { false }
+          allow(@damage2).to receive(:is_treatable?) { false }
+          allow(@damage3).to receive(:is_treatable?) { false }
+          allow(@char).to receive(:damage) { [@damage1, @damage2, @damage3] }
+          expect(FS3Combat.worst_treatable_wound(@char)).to be_nil
         end
         
       end
@@ -193,33 +193,33 @@ module AresMUSH
           @patient = double
           @doctor = double
           
-          @patient.stub(:name) { "Bob" }
-          @doctor.stub(:name) { "Doc" }
-          FS3Combat.stub(:combat)
+          allow(@patient).to receive(:name) { "Bob" }
+          allow(@doctor).to receive(:name) { "Doc" }
+          allow(FS3Combat).to receive(:combat)
           @damage = double
-          FS3Combat.stub(:worst_treatable_wound) { @damage }
+          allow(FS3Combat).to receive(:worst_treatable_wound) { @damage }
         end
         
         it "should not do anything if no treatable wounds" do
-          FS3Combat.should_receive(:worst_treatable_wound).with(@patient) { nil }
-          FS3Combat.should_not_receive(:heal)
-          FS3Combat.treat(@patient, @doctor).should eq "fs3combat.no_treatable_wounds"
+          expect(FS3Combat).to receive(:worst_treatable_wound).with(@patient) { nil }
+          expect(FS3Combat).to_not receive(:heal)
+          expect(FS3Combat.treat(@patient, @doctor)).to eq "fs3combat.no_treatable_wounds"
         end
         
         it "should add a healing point if treat roll successful" do
-          Global.stub(:read_config).with("fs3combat", "treat_skill") { "Medicine" }
-          @doctor.should_receive(:roll_ability).with("Medicine") { { successes: 2 }}
+          allow(Global).to receive(:read_config).with("fs3combat", "treat_skill") { "Medicine" }
+          expect(@doctor).to receive(:roll_ability).with("Medicine") { { successes: 2 }}
           
-          FS3Combat.should_receive(:heal).with(@damage, 1)
-          FS3Combat.treat(@patient, @doctor).should eq "fs3combat.treat_success"
+          expect(FS3Combat).to receive(:heal).with(@damage, 1)
+          expect(FS3Combat.treat(@patient, @doctor)).to eq "fs3combat.treat_success"
         end
         
         it "should not heal if treat roll unsuccessful" do
-          Global.stub(:read_config).with("fs3combat", "treat_skill") { "Medicine" }
-          @doctor.should_receive(:roll_ability).with("Medicine") { { successes: 0 }}
+          allow(Global).to receive(:read_config).with("fs3combat", "treat_skill") { "Medicine" }
+          expect(@doctor).to receive(:roll_ability).with("Medicine") { { successes: 0 }}
           
-          FS3Combat.should_not_receive(:heal)
-          FS3Combat.treat(@patient, @doctor).should eq "fs3combat.treat_failed"
+          expect(FS3Combat).to_not receive(:heal)
+          expect(FS3Combat.treat(@patient, @doctor)).to eq "fs3combat.treat_failed"
         end
       end
     end

--- a/plugins/fs3combat/specs/damage_specs.rb
+++ b/plugins/fs3combat/specs/damage_specs.rb
@@ -4,42 +4,42 @@ module AresMUSH
       
       describe :wound_mod do
         before do
-          Global.stub(:read_config).with("fs3combat", "damage_mods") { { "HEAL" => 0, "GRAZE" => 1, "IMPAIR" => 3  } }          
+          allow(Global).to receive(:read_config).with("fs3combat", "damage_mods") { { "HEAL" => 0, "GRAZE" => 1, "IMPAIR" => 3  } }          
         end
         
         it "should return the correct wound modifier" do
           wound = Damage.new(:current_severity => "IMPAIR")
-          wound.wound_mod.should eq 3
+          expect(wound.wound_mod).to eq 3
         end
         
         it "should return 0 for a healed wound" do
           wound = Damage.new(:current_severity => "HEAL")
-          wound.wound_mod.should eq 0
+          expect(wound.wound_mod).to eq 0
         end
 
         it "should return one third for a treated wound" do
           wound = Damage.new(:current_severity => "IMPAIR", :healed => true)
-          wound.wound_mod.should eq 1
+          expect(wound.wound_mod).to eq 1
         end        
       end
       
       describe :is_treatable? do
         it "should be treatable if it's been less than four hours" do
-          Time.stub(:now) { Time.new(2014, 01, 01, 8, 0, 0) }
+          allow(Time).to receive(:now) { Time.new(2014, 01, 01, 8, 0, 0) }
           damage = Damage.new(created_at: Time.new(2014, 01, 01, 4, 1, 0))
-          damage.is_treatable?.should be true
+          expect(damage.is_treatable?).to be true
         end
         
         it "should not be treatable if it's been more than four hours" do
-          Time.stub(:now) { Time.new(2014, 01, 01, 8, 0, 0) }
+          allow(Time).to receive(:now) { Time.new(2014, 01, 01, 8, 0, 0) }
           damage = Damage.new(created_at: Time.new(2014, 01, 01, 3, 59, 0))
-          damage.is_treatable?.should be false
+          expect(damage.is_treatable?).to be false
         end
         
         it "should not be treatable if it's already been treated" do
-          Time.stub(:now) { Time.new(2014, 01, 01, 8, 0, 0) }
+          allow(Time).to receive(:now) { Time.new(2014, 01, 01, 8, 0, 0) }
           damage = Damage.new(created_at: Time.new(2014, 01, 01, 4, 1, 0), :healed => true)
-          damage.is_treatable?.should be false
+          expect(damage.is_treatable?).to be false
         end
         
       end

--- a/plugins/fs3combat/specs/gear_specs.rb
+++ b/plugins/fs3combat/specs/gear_specs.rb
@@ -7,9 +7,9 @@ module AresMUSH
         @client = double
         @combatant = double
         
-        @combatant.stub(:name) { "Trooper" }
+        allow(@combatant).to receive(:name) { "Trooper" }
         
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
 
       describe :armor_stat do
@@ -17,30 +17,30 @@ module AresMUSH
           specials = {
             "Helmet" => { "defense" => 2, "protection" => { "Head" => 2 } },
             "Cup" => { "protection" => { "Groin" => 2 } } }
-          FS3Combat.stub(:armor_specials) { specials }
-          FS3Combat.stub(:armor).with("Military") { { "defense" => 1, "protection" => { "Head" => 1, "Body" => 4 } } }
+          allow(FS3Combat).to receive(:armor_specials) { specials }
+          allow(FS3Combat).to receive(:armor).with("Military") { { "defense" => 1, "protection" => { "Head" => 1, "Body" => 4 } } }
         end
         
         it "should return nil if armor not found" do
-          FS3Combat.stub(:armor).with("Police") { nil }
-          FS3Combat.armor_stat("Police", "protection").should be_nil
+          allow(FS3Combat).to receive(:armor).with("Police") { nil }
+          expect(FS3Combat.armor_stat("Police", "protection")).to be_nil
         end
         
         it "should add special protection together" do
           protection = FS3Combat.armor_stat("Military+Helmet+Cup", "protection")
-          protection['Head'].should eq 3
-          protection['Body'].should eq 4
-          protection['Groin'].should eq 2
+          expect(protection['Head']).to eq 3
+          expect(protection['Body']).to eq 4
+          expect(protection['Groin']).to eq 2
         end
         
         it "should add other stats" do
           defense = FS3Combat.armor_stat("Military+Helmet", "defense")
-          defense.should eq 3
+          expect(defense).to eq 3
         end
         
         it "should not add anything if no special stat exists" do
           defense = FS3Combat.armor_stat("Military+Cup", "defense")
-          defense.should eq 1
+          expect(defense).to eq 1
         end
         
         
@@ -48,66 +48,66 @@ module AresMUSH
       
       describe :weapon_stat do
         before do
-          FS3Combat.stub(:weapon).with("Rifle") { { "penetration" => 3, "lethality" => 10 } }
+          allow(FS3Combat).to receive(:weapon).with("Rifle") { { "penetration" => 3, "lethality" => 10 } }
           specials = {
             "Ap" => { "penetration" => 2 },
             "Silencer" => { "lethality" => -5 }
           }
-          FS3Combat.stub(:weapon_specials) { specials }
+          allow(FS3Combat).to receive(:weapon_specials) { specials }
         end
         
         it "should return nil if weapon not found" do
-           FS3Combat.stub(:weapon) { nil }
-           FS3Combat.weapon_stat("Banjo", "penetration").should be_nil
+           allow(FS3Combat).to receive(:weapon) { nil }
+           expect(FS3Combat.weapon_stat("Banjo", "penetration")).to be_nil
         end
 
         it "should return nil if weapon has no stat" do
-           FS3Combat.weapon_stat("Rifle", "moxie").should be_nil
+           expect(FS3Combat.weapon_stat("Rifle", "moxie")).to be_nil
         end
         
         it "should return a value for a weapon without a special" do
-          FS3Combat.weapon_stat("Rifle", "penetration").should eq 3
+          expect(FS3Combat.weapon_stat("Rifle", "penetration")).to eq 3
         end
 
         it "should return raw value for a weapon with an invalid special" do
-          FS3Combat.weapon_stat("Rifle+Foo", "penetration").should eq 3
+          expect(FS3Combat.weapon_stat("Rifle+Foo", "penetration")).to eq 3
         end
         
         it "should adjust a value for a weapon with a special" do
-          FS3Combat.weapon_stat("Rifle+Ap", "penetration").should eq 5
+          expect(FS3Combat.weapon_stat("Rifle+Ap", "penetration")).to eq 5
         end
         
         it "should handle multiple specials" do
-          FS3Combat.weapon_stat("Rifle+Ap+Silencer", "penetration").should eq 5
+          expect(FS3Combat.weapon_stat("Rifle+Ap+Silencer", "penetration")).to eq 5
         end
       end
       
       describe :set_default_gear do
         before do
-          FS3Combat.stub(:combatant_type_stat) { nil }
-          FS3Combat.stub(:combatant_type_stat) { nil }
+          allow(FS3Combat).to receive(:combatant_type_stat) { nil }
+          allow(FS3Combat).to receive(:combatant_type_stat) { nil }
         end
         
         it "should set a weapon if set" do
-          FS3Combat.should_receive(:combatant_type_stat).with("soldier", "weapon") { "rifle" }
-          FS3Combat.should_receive(:combatant_type_stat).with("soldier", "weapon_specials") { "specials" }
-          FS3Combat.should_receive(:set_weapon).with(@enactor, @combatant, "rifle", "specials")
+          expect(FS3Combat).to receive(:combatant_type_stat).with("soldier", "weapon") { "rifle" }
+          expect(FS3Combat).to receive(:combatant_type_stat).with("soldier", "weapon_specials") { "specials" }
+          expect(FS3Combat).to receive(:set_weapon).with(@enactor, @combatant, "rifle", "specials")
           FS3Combat.set_default_gear(@enactor, @combatant, "soldier")
         end
         
         it "should not set a weapon if none set" do
-          FS3Combat.should_not_receive(:set_weapon)
+          expect(FS3Combat).to_not receive(:set_weapon)
           FS3Combat.set_default_gear(@enactor, @combatant, "soldier")
         end
 
         it "should set armor if set" do
-          FS3Combat.should_receive(:combatant_type_stat).with("soldier", "armor") { "kevlar" }
-          FS3Combat.should_receive(:set_armor).with(@enactor, @combatant, "kevlar")
+          expect(FS3Combat).to receive(:combatant_type_stat).with("soldier", "armor") { "kevlar" }
+          expect(FS3Combat).to receive(:set_armor).with(@enactor, @combatant, "kevlar")
           FS3Combat.set_default_gear(@enactor, @combatant, "soldier")
         end
         
         it "should not set armor if none set" do
-          FS3Combat.should_not_receive(:set_armor)
+          expect(FS3Combat).to_not receive(:set_armor)
           FS3Combat.set_default_gear(@enactor, @combatant, "soldier")
         end
 
@@ -115,44 +115,44 @@ module AresMUSH
       
       describe :set_weapon do
         before do
-          @combatant.stub(:combat) { @combat }
-          FS3Combat.stub(:emit_to_combat) {}
-          FS3Combat.stub(:npcmaster_text) { "npcmaster" }
-          @combatant.stub(:update)
-          FS3Combat.stub(:weapon_stat)
-          @combatant.stub(:action=)
-          @combatant.stub(:weapon)
-          @combatant.stub(:weapon_specials)
+          allow(@combatant).to receive(:combat) { @combat }
+          allow(FS3Combat).to receive(:emit_to_combat) {}
+          allow(FS3Combat).to receive(:npcmaster_text) { "npcmaster" }
+          allow(@combatant).to receive(:update)
+          allow(FS3Combat).to receive(:weapon_stat)
+          allow(@combatant).to receive(:action=)
+          allow(@combatant).to receive(:weapon)
+          allow(@combatant).to receive(:weapon_specials)
         end
 
         it "should pretty up the weapon and specials if set" do
-          @combatant.should_receive(:update).with(weapon_name: "Rifle")
-          @combatant.should_receive(:update).with(weapon_specials: ["S1", "S2"])
+          expect(@combatant).to receive(:update).with(weapon_name: "Rifle")
+          expect(@combatant).to receive(:update).with(weapon_specials: ["S1", "S2"])
           FS3Combat.set_weapon(@enactor, @combatant, "rifle", [ "s1", "s2" ])
         end
         
         it "should reset ammo" do
-          FS3Combat.should_receive(:weapon_stat).with("rifle", "ammo") { 22 }
-          @combatant.should_receive(:update).with(ammo: 22)
+          expect(FS3Combat).to receive(:weapon_stat).with("rifle", "ammo") { 22 }
+          expect(@combatant).to receive(:update).with(ammo: 22)
           FS3Combat.set_weapon(@enactor, @combatant, "rifle", [ "s1", "s2" ])
         end
         
         it "should reset stats if nil" do
-          @combatant.should_receive(:update).with(weapon_name: "Unarmed")
-          @combatant.should_receive(:update).with(weapon_specials: [])
-          @combatant.should_receive(:update).with(ammo: 0)
-          @combatant.should_receive(:update).with(max_ammo: 0)
+          expect(@combatant).to receive(:update).with(weapon_name: "Unarmed")
+          expect(@combatant).to receive(:update).with(weapon_specials: [])
+          expect(@combatant).to receive(:update).with(ammo: 0)
+          expect(@combatant).to receive(:update).with(max_ammo: 0)
           FS3Combat.set_weapon(@enactor, @combatant, nil, nil)
         end
         
         it "should reset their combat action" do
-          @combatant.should_receive(:update).with(action_klass: nil)
-          @combatant.should_receive(:update).with(action_args: nil)
+          expect(@combatant).to receive(:update).with(action_klass: nil)
+          expect(@combatant).to receive(:update).with(action_args: nil)
           FS3Combat.set_weapon(@enactor, @combatant, nil, nil)
         end
         
         it "should emit to combat" do
-          FS3Combat.should_receive(:emit_to_combat).with(@combat, "fs3combat.weapon_changed", "npcmaster")
+          expect(FS3Combat).to receive(:emit_to_combat).with(@combat, "fs3combat.weapon_changed", "npcmaster")
           FS3Combat.set_weapon(@enactor, @combatant, "rifle", [ "s1", "s2" ])
         end
       end

--- a/plugins/fs3combat/specs/general_helper_specs.rb
+++ b/plugins/fs3combat/specs/general_helper_specs.rb
@@ -8,30 +8,30 @@ module AresMUSH
           @combat1 = double
           @combat2 = double
           @client = double
-          Combat.stub(:[]).with(1) { @combat1 }
-          Combat.stub(:[]).with(2) { @combat2 }
-          Combat.stub(:[]).with(3) { nil }
-          SpecHelpers.stub_translate_for_testing
+          allow(Combat).to receive(:[]).with(1) { @combat1 }
+          allow(Combat).to receive(:[]).with(2) { @combat2 }
+          allow(Combat).to receive(:[]).with(3) { nil }
+          stub_translate_for_testing
         end
         
         it "should fail if not a number" do
-          @client.should_receive(:emit_failure).with("fs3combat.invalid_combat_number")
-          FS3Combat.find_combat_by_number(@client, "A").should be_nil
+          expect(@client).to receive(:emit_failure).with("fs3combat.invalid_combat_number")
+          expect(FS3Combat.find_combat_by_number(@client, "A")).to be_nil
         end
         
         it "should fail if not a valid number" do
-          @client.should_receive(:emit_failure).with("fs3combat.invalid_combat_number")
-          FS3Combat.find_combat_by_number(@client, 3).should be_nil
+          expect(@client).to receive(:emit_failure).with("fs3combat.invalid_combat_number")
+          expect(FS3Combat.find_combat_by_number(@client, 3)).to be_nil
         end
         
         it "should succeed if valid number string specified" do
-          FS3Combat.find_combat_by_number(@client, "1").should eq @combat1
-          FS3Combat.find_combat_by_number(@client, "2").should eq @combat2
+          expect(FS3Combat.find_combat_by_number(@client, "1")).to eq @combat1
+          expect(FS3Combat.find_combat_by_number(@client, "2")).to eq @combat2
         end
         
         it "should succeed if valid number specified" do
-          FS3Combat.find_combat_by_number(@client, 1).should eq @combat1
-          FS3Combat.find_combat_by_number(@client, 2).should eq @combat2
+          expect(FS3Combat.find_combat_by_number(@client, 1)).to eq @combat1
+          expect(FS3Combat.find_combat_by_number(@client, 2)).to eq @combat2
         end
         
       end
@@ -40,28 +40,28 @@ module AresMUSH
     describe :get_initiative_order do
       it "should return combatants in order of initiative roll" do
         @combat = double
-        @combat.stub(:log)
+        allow(@combat).to receive(:log)
         @combatant1 = double
         @combatant2 = double
         @combatant3 = double
         
-        @combatant1.stub(:name) { "A" }
-        @combatant2.stub(:name) { "B" }
-        @combatant3.stub(:name) { "C" }
+        allow(@combatant1).to receive(:name) { "A" }
+        allow(@combatant2).to receive(:name) { "B" }
+        allow(@combatant3).to receive(:name) { "C" }
         
-        @combatant1.stub(:id) { 1 }
-        @combatant2.stub(:id) { 2 }
-        @combatant3.stub(:id) { 3 }
+        allow(@combatant1).to receive(:id) { 1 }
+        allow(@combatant2).to receive(:id) { 2 }
+        allow(@combatant3).to receive(:id) { 3 }
 
-        @combat.stub(:active_combatants) { [ @combatant1, @combatant2, @combatant3 ]}
+        allow(@combat).to receive(:active_combatants) { [ @combatant1, @combatant2, @combatant3 ]}
         
-        Global.stub(:read_config).with("fs3combat", "initiative_skill") { "init" }
+        allow(Global).to receive(:read_config).with("fs3combat", "initiative_skill") { "init" }
         
-        FS3Combat.should_receive(:roll_initiative).with(@combatant1, "init") { 3 }
-        FS3Combat.should_receive(:roll_initiative).with(@combatant2, "init") { 5 }
-        FS3Combat.should_receive(:roll_initiative).with(@combatant3, "init") { 1 }
+        expect(FS3Combat).to receive(:roll_initiative).with(@combatant1, "init") { 3 }
+        expect(FS3Combat).to receive(:roll_initiative).with(@combatant2, "init") { 5 }
+        expect(FS3Combat).to receive(:roll_initiative).with(@combatant3, "init") { 1 }
         
-        FS3Combat.get_initiative_order(@combat).should eq [ 2, 1, 3 ]
+        expect(FS3Combat.get_initiative_order(@combat)).to eq [ 2, 1, 3 ]
       end
     end
     

--- a/plugins/fs3combat/specs/joining_specs.rb
+++ b/plugins/fs3combat/specs/joining_specs.rb
@@ -7,41 +7,41 @@ module AresMUSH
           @enactor = double
           @client = double
           
-          FS3Combat.stub(:emit_to_combat) {}
-          FS3Combat.stub(:is_in_combat?) { false }
-          ClassTargetFinder.stub(:find) { FindResult.new(nil, "error") }
-          FS3Combat.stub(:combatant_type_stat) { nil }
-          FS3Combat.stub(:set_default_gear)
-          SpecHelpers.stub_translate_for_testing
+          allow(FS3Combat).to receive(:emit_to_combat) {}
+          allow(FS3Combat).to receive(:is_in_combat?) { false }
+          allow(ClassTargetFinder).to receive(:find) { FindResult.new(nil, "error") }
+          allow(FS3Combat).to receive(:combatant_type_stat) { nil }
+          allow(FS3Combat).to receive(:set_default_gear)
+          stub_translate_for_testing
         end
   
         it "should fail if already in combat" do
-          FS3Combat.should_receive(:is_in_combat?).with("Bob") { true }
-          @client.should_receive(:emit_failure).with("fs3combat.already_in_combat")
+          expect(FS3Combat).to receive(:is_in_combat?).with("Bob") { true }
+          expect(@client).to receive(:emit_failure).with("fs3combat.already_in_combat")
           FS3Combat.join_combat(@combat, "Bob", "soldier", @enactor, @client)
         end
         
         it "should create a NPC if char not found" do
-          ClassTargetFinder.should_receive(:find).with("Bob", Character, @enactor) { FindResult.new(nil, "error") }
+          expect(ClassTargetFinder).to receive(:find).with("Bob", Character, @enactor) { FindResult.new(nil, "error") }
           npc = double
-          Npc.should_receive(:create).with(name: "Bob", combat: @combat) { npc }
-          Combatant.should_receive(:create) do |params|
-            params[:combatant_type].should eq "soldier"
-            params[:team].should eq 9
-            params[:npc].should eq npc
-            params[:combat].should eq @combat
+          expect(Npc).to receive(:create).with(name: "Bob", combat: @combat) { npc }
+          expect(Combatant).to receive(:create) do |params|
+            expect(params[:combatant_type]).to eq "soldier"
+            expect(params[:team]).to eq 9
+            expect(params[:npc]).to eq npc
+            expect(params[:combat]).to eq @combat
           end
           FS3Combat.join_combat(@combat, "Bob", "soldier", @enactor, @client)
         end
         
         it "should create a combatant for a character if found" do
           char = double
-          ClassTargetFinder.should_receive(:find).with("Bob", Character, @enactor) { FindResult.new(char) }
-          Combatant.should_receive(:create) do |params|
-            params[:combatant_type].should eq "soldier"
-            params[:team].should eq 1
-            params[:character].should eq char
-            params[:combat].should eq @combat
+          expect(ClassTargetFinder).to receive(:find).with("Bob", Character, @enactor) { FindResult.new(char) }
+          expect(Combatant).to receive(:create) do |params|
+            expect(params[:combatant_type]).to eq "soldier"
+            expect(params[:team]).to eq 1
+            expect(params[:character]).to eq char
+            expect(params[:combat]).to eq @combat
           end
           FS3Combat.join_combat(@combat, "Bob", "soldier", @enactor, @client)
         end
@@ -51,28 +51,28 @@ module AresMUSH
           char = double
           combatant = double
           vehicle = double
-          ClassTargetFinder.should_receive(:find).with("Bob", Character, @enactor) { FindResult.new(char) }
-          Combatant.stub(:create) { combatant }
-          FS3Combat.should_receive(:combatant_type_stat).with("viper", "vehicle") { "Viper" }
-          FS3Combat.should_receive(:find_or_create_vehicle).with(@combat, "Viper") { vehicle }
-          FS3Combat.should_receive(:join_vehicle).with(@combat, combatant, vehicle, "Pilot")
+          expect(ClassTargetFinder).to receive(:find).with("Bob", Character, @enactor) { FindResult.new(char) }
+          allow(Combatant).to receive(:create) { combatant }
+          expect(FS3Combat).to receive(:combatant_type_stat).with("viper", "vehicle") { "Viper" }
+          expect(FS3Combat).to receive(:find_or_create_vehicle).with(@combat, "Viper") { vehicle }
+          expect(FS3Combat).to receive(:join_vehicle).with(@combat, combatant, vehicle, "Pilot")
           FS3Combat.join_combat(@combat, "Bob", "viper", @enactor, @client)
         end
         
         
         it "should emit join message to combat" do
           combatant = double
-          Npc.stub(:create)
-          Combatant.stub(:create) { combatant }
-          FS3Combat.should_receive(:emit_to_combat).with(@combat, "fs3combat.has_joined")
+          allow(Npc).to receive(:create)
+          allow(Combatant).to receive(:create) { combatant }
+          expect(FS3Combat).to receive(:emit_to_combat).with(@combat, "fs3combat.has_joined")
           FS3Combat.join_combat(@combat, "Bob", "soldier", @enactor, @client)
         end
         
         it "should set default gear" do
           combatant = double
-          Npc.stub(:create)
-          Combatant.stub(:create) { combatant }
-          FS3Combat.should_receive(:set_default_gear).with(@enactor, combatant, "soldier")
+          allow(Npc).to receive(:create)
+          allow(Combatant).to receive(:create) { combatant }
+          expect(FS3Combat).to receive(:set_default_gear).with(@enactor, combatant, "soldier")
           FS3Combat.join_combat(@combat, "Bob", "soldier", @enactor, @client)
         end
       end

--- a/plugins/fs3combat/specs/vehicles_specs.rb
+++ b/plugins/fs3combat/specs/vehicles_specs.rb
@@ -2,7 +2,7 @@ module AresMUSH
   module FS3Combat
     describe FS3Combat do
       before do
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
       
       describe :find_or_create_vehicle do
@@ -12,34 +12,34 @@ module AresMUSH
       
         it "should return a vehicle that already exists" do
           v = double
-          @instance.stub(:find_vehicle_by_name).with("abc") { v }
-          FS3Combat.find_or_create_vehicle(@instance, "abc").should eq v
+          allow(@instance).to receive(:find_vehicle_by_name).with("abc") { v }
+          expect(FS3Combat.find_or_create_vehicle(@instance, "abc")).to eq v
         end
   
         it "should return nil for invalid vehicle type" do
-          Global.stub(:read_config).with("fs3combat", "vehicles") { { "Viper" => {} } }
-          @instance.stub(:find_vehicle_by_name).with("abc") { nil }
-          FS3Combat.find_or_create_vehicle(@instance, "abc").should eq nil
+          allow(Global).to receive(:read_config).with("fs3combat", "vehicles") { { "Viper" => {} } }
+          allow(@instance).to receive(:find_vehicle_by_name).with("abc") { nil }
+          expect(FS3Combat.find_or_create_vehicle(@instance, "abc")).to eq nil
         end
   
         it "should add a new vehicle" do
-          Global.stub(:read_config).with("fs3combat", "vehicles") { { "Viper" => {} } }
-          @instance.stub(:find_vehicle_by_name).with("Viper") { nil }
+          allow(Global).to receive(:read_config).with("fs3combat", "vehicles") { { "Viper" => {} } }
+          allow(@instance).to receive(:find_vehicle_by_name).with("Viper") { nil }
           v = double
-          Vehicle.stub(:create) do |args|
-            args[:combat].should eq @instance
-            args[:vehicle_type].should eq "Viper"
+          allow(Vehicle).to receive(:create) do |args|
+            expect(args[:combat]).to eq @instance
+            expect(args[:vehicle_type]).to eq "Viper"
             v
           end
-          FS3Combat.find_or_create_vehicle(@instance, "Viper").should eq v
+          expect(FS3Combat.find_or_create_vehicle(@instance, "Viper")).to eq v
         end
         
         it "should find a vehicle with a case-insensitive name" do
-          Global.stub(:read_config).with("fs3combat", "vehicles") { { "AA Battery" => {} } }
-          @instance.stub(:find_vehicle_by_name).with("aa battery") { nil }
+          allow(Global).to receive(:read_config).with("fs3combat", "vehicles") { { "AA Battery" => {} } }
+          allow(@instance).to receive(:find_vehicle_by_name).with("aa battery") { nil }
           v = double
-          Vehicle.stub(:create) { v }
-          FS3Combat.find_or_create_vehicle(@instance, "aa battery").should eq v
+          allow(Vehicle).to receive(:create) { v }
+          expect(FS3Combat.find_or_create_vehicle(@instance, "aa battery")).to eq v
         end
       end
       
@@ -49,60 +49,60 @@ module AresMUSH
           @combat = double
           @combatant = double
           
-          @vehicle.stub(:name) { "Viper-1" }
-          @combatant.stub(:name) { "Bob" }
-          @combatant.stub(:update)
-          @vehicle.stub(:pilot) { nil }
-          @vehicle.stub(:vehicle_type) { "Viper" }
-          FS3Combat.stub(:emit_to_combat)
-          @vehicle.stub(:update)
+          allow(@vehicle).to receive(:name) { "Viper-1" }
+          allow(@combatant).to receive(:name) { "Bob" }
+          allow(@combatant).to receive(:update)
+          allow(@vehicle).to receive(:pilot) { nil }
+          allow(@vehicle).to receive(:vehicle_type) { "Viper" }
+          allow(FS3Combat).to receive(:emit_to_combat)
+          allow(@vehicle).to receive(:update)
 
-          FS3Combat.stub(:set_weapon)
-          FS3Combat.stub(:vehicle_stat) { [] }
+          allow(FS3Combat).to receive(:set_weapon)
+          allow(FS3Combat).to receive(:vehicle_stat) { [] }
         end
         
         describe "pilot" do
           it "should move the existing pilot to the passenger list if someone else takes over" do
             old_pilot = double
-            @vehicle.stub(:pilot) { old_pilot }
+            allow(@vehicle).to receive(:pilot) { old_pilot }
             
-            old_pilot.should_receive(:update).with(piloting: nil)
-            old_pilot.should_receive(:update).with(riding_in: @vehicle)
-            @vehicle.should_receive(:update).with(pilot: @combatant)
+            expect(old_pilot).to receive(:update).with(piloting: nil)
+            expect(old_pilot).to receive(:update).with(riding_in: @vehicle)
+            expect(@vehicle).to receive(:update).with(pilot: @combatant)
             FS3Combat.join_vehicle(@combat, @combatant, @vehicle, "Pilot")
           end
           
           it "should not move pilot if they're the same as the old pilot" do
-            @vehicle.stub(:pilot) { @combatant }
-            @vehicle.should_receive(:update).with(pilot: @combatant)
+            allow(@vehicle).to receive(:pilot) { @combatant }
+            expect(@vehicle).to receive(:update).with(pilot: @combatant)
             FS3Combat.join_vehicle(@combat, @combatant, @vehicle, "Pilot")
           end
           
           it "should update the pilot's vehicle stat" do
-            @combatant.should_receive(:update).with(piloting: @vehicle)
+            expect(@combatant).to receive(:update).with(piloting: @vehicle)
             FS3Combat.join_vehicle(@combat, @combatant, @vehicle, "Pilot")
           end
           
           it "should set up default vehicle weapon" do
-            FS3Combat.should_receive(:vehicle_stat).with("Viper", "weapons") { ["KEW", "Missile"]}
-            FS3Combat.should_receive(:set_weapon).with(nil, @combatant, "KEW")
+            expect(FS3Combat).to receive(:vehicle_stat).with("Viper", "weapons") { ["KEW", "Missile"]}
+            expect(FS3Combat).to receive(:set_weapon).with(nil, @combatant, "KEW")
             FS3Combat.join_vehicle(@combat, @combatant, @vehicle, "Pilot")
           end
         
           it "should emit to combat" do
-            FS3Combat.should_receive(:emit_to_combat).with(@combat, "fs3combat.new_pilot")
+            expect(FS3Combat).to receive(:emit_to_combat).with(@combat, "fs3combat.new_pilot")
             FS3Combat.join_vehicle(@combat, @combatant, @vehicle, "Pilot")
           end
         end
         
         describe "passenger" do
           it "should update the pilot's vehicle stat" do
-            @combatant.should_receive(:update).with(riding_in: @vehicle)
+            expect(@combatant).to receive(:update).with(riding_in: @vehicle)
             FS3Combat.join_vehicle(@combat, @combatant, @vehicle, "Passenger")
           end
           
           it "should emit to combat" do
-            FS3Combat.should_receive(:emit_to_combat).with(@combat, "fs3combat.new_passenger")
+            expect(FS3Combat).to receive(:emit_to_combat).with(@combat, "fs3combat.new_passenger")
             FS3Combat.join_vehicle(@combat, @combatant, @vehicle, "Passenger")
           end
         end
@@ -114,39 +114,39 @@ module AresMUSH
           @combat = double
           @combatant = double
         
-          @vehicle.stub(:name) { "Viper-1" }
-          @combatant.stub(:name) { "Bob" }
-          FS3Combat.stub(:emit_to_combat)
-          @combatant.stub(:update)
-          @vehicle.stub(:update)
+          allow(@vehicle).to receive(:name) { "Viper-1" }
+          allow(@combatant).to receive(:name) { "Bob" }
+          allow(FS3Combat).to receive(:emit_to_combat)
+          allow(@combatant).to receive(:update)
+          allow(@vehicle).to receive(:update)
           
-          FS3Combat.stub(:set_default_gear) {}
-          Global.stub(:read_config).with("fs3combat", "default_type") { "soldier" }
+          allow(FS3Combat).to receive(:set_default_gear) {}
+          allow(Global).to receive(:read_config).with("fs3combat", "default_type") { "soldier" }
         end
       
         it "should remove a pilot" do
-          @combatant.stub(:piloting) { @vehicle }
-          @combatant.should_receive(:update).with(piloting: nil)
-          @vehicle.should_receive(:update).with(pilot: nil)
+          allow(@combatant).to receive(:piloting) { @vehicle }
+          expect(@combatant).to receive(:update).with(piloting: nil)
+          expect(@vehicle).to receive(:update).with(pilot: nil)
           FS3Combat.leave_vehicle(@combat, @combatant)
         end
         
         it "should emit to combat" do
-          @combatant.stub(:piloting) { @vehicle }
-          FS3Combat.should_receive(:emit_to_combat).with(@combat, "fs3combat.disembarks_vehicle")
+          allow(@combatant).to receive(:piloting) { @vehicle }
+          expect(FS3Combat).to receive(:emit_to_combat).with(@combat, "fs3combat.disembarks_vehicle")
           FS3Combat.leave_vehicle(@combat, @combatant)
         end
       
         it "should remove a passenger" do
-          @combatant.stub(:piloting) { nil }
-          @combatant.stub(:riding_in) { @vehicle }
-          @combatant.should_receive(:update).with(riding_in: nil)
+          allow(@combatant).to receive(:piloting) { nil }
+          allow(@combatant).to receive(:riding_in) { @vehicle }
+          expect(@combatant).to receive(:update).with(riding_in: nil)
           FS3Combat.leave_vehicle(@combat, @combatant)
         end
         
         it "should reset gear" do
-          @combatant.stub(:piloting) { @vehicle }
-          FS3Combat.should_receive(:set_default_gear).with(nil, @combatant, "soldier")
+          allow(@combatant).to receive(:piloting) { @vehicle }
+          expect(FS3Combat).to receive(:set_default_gear).with(nil, @combatant, "soldier")
           FS3Combat.leave_vehicle(@combat, @combatant)
         end
         

--- a/plugins/fs3skills/specs/ability_point_counter_specs.rb
+++ b/plugins/fs3skills/specs/ability_point_counter_specs.rb
@@ -3,7 +3,7 @@ module AresMUSH
     describe FS3Skills do
 
       before do
-        Global.stub(:read_config).with("fs3skills", "free_languages") { 3 }
+        allow(Global).to receive(:read_config).with("fs3skills", "free_languages") { 3 }
       end
       
       describe :points_on_attrs do
@@ -16,8 +16,8 @@ module AresMUSH
                     FS3Attribute.new(rating: 2), 
                     FS3Attribute.new(rating: 3),
                     FS3Attribute.new(rating: 4) ]
-          @char.stub(:fs3_attributes) { attrs }
-          AbilityPointCounter.points_on_attrs(@char).should eq 12
+          allow(@char).to receive(:fs3_attributes) { attrs }
+          expect(AbilityPointCounter.points_on_attrs(@char)).to eq 12
         end
         
         it "should not count average or below average" do
@@ -25,8 +25,8 @@ module AresMUSH
                     FS3Attribute.new(rating: 2), 
                     FS3Attribute.new(rating: 2),
                     FS3Attribute.new(rating: 2) ]
-          @char.stub(:fs3_attributes) { attrs }
-          AbilityPointCounter.points_on_attrs(@char).should eq 0
+          allow(@char).to receive(:fs3_attributes) { attrs }
+          expect(AbilityPointCounter.points_on_attrs(@char)).to eq 0
         end
       end
       
@@ -40,8 +40,8 @@ module AresMUSH
                      FS3ActionSkill.new(rating: 3), 
                      FS3ActionSkill.new(rating: 4),
                      FS3ActionSkill.new(rating: 5) ]
-          @char.stub(:fs3_action_skills) { action }
-          AbilityPointCounter.points_on_action(@char).should eq 10
+          allow(@char).to receive(:fs3_action_skills) { action }
+          expect(AbilityPointCounter.points_on_action(@char)).to eq 10
         end
         
         it "should not count everyman or poor" do
@@ -49,53 +49,53 @@ module AresMUSH
                      FS3ActionSkill.new(rating: 1), 
                      FS3ActionSkill.new(rating: 1),
                      FS3ActionSkill.new(rating: 0) ]
-          @char.stub(:fs3_action_skills) { action }
-          AbilityPointCounter.points_on_action(@char).should eq 0
+          allow(@char).to receive(:fs3_action_skills) { action }
+          expect(AbilityPointCounter.points_on_action(@char)).to eq 0
         end
       end
 
       describe :points_on_background do
         before do
           @char = double
-          Global.stub(:read_config).with("fs3skills", "free_backgrounds") { 5 }
+          allow(Global).to receive(:read_config).with("fs3skills", "free_backgrounds") { 5 }
         end
         
         it "should count past the free ones" do
           bg = [ FS3BackgroundSkill.new(rating: 3), 
                  FS3BackgroundSkill.new(rating: 3), 
                  FS3BackgroundSkill.new(rating: 2) ]
-          @char.stub(:fs3_background_skills) { bg }
-          AbilityPointCounter.points_on_background(@char).should eq 3
+          allow(@char).to receive(:fs3_background_skills) { bg }
+          expect(AbilityPointCounter.points_on_background(@char)).to eq 3
         end
         
         it "should not count if below free ones" do
           bg = [ FS3BackgroundSkill.new(rating: 2), 
                  FS3BackgroundSkill.new(rating: 1), 
                  FS3BackgroundSkill.new(rating: 1) ]
-          @char.stub(:fs3_background_skills) { bg }
-          AbilityPointCounter.points_on_background(@char).should eq 0
+          allow(@char).to receive(:fs3_background_skills) { bg }
+          expect(AbilityPointCounter.points_on_background(@char)).to eq 0
         end
       end
       
       describe :points_on_language do
         before do
           @char = double
-          Global.stub(:read_config).with("fs3skills", "free_languages") { 4 }
+          allow(Global).to receive(:read_config).with("fs3skills", "free_languages") { 4 }
         end
         
         it "should count past the free ones" do
           lang = [ FS3Language.new(rating: 3), 
                    FS3Language.new(rating: 3), 
                    FS3Language.new(rating: 2) ]
-          @char.stub(:fs3_languages) { lang }
-          AbilityPointCounter.points_on_language(@char).should eq 4
+          allow(@char).to receive(:fs3_languages) { lang }
+          expect(AbilityPointCounter.points_on_language(@char)).to eq 4
         end
         
         it "should not count if below free ones" do
           lang = [ FS3Language.new(rating: 2), 
                    FS3Language.new(rating: 1) ]
-          @char.stub(:fs3_languages) { lang }
-          AbilityPointCounter.points_on_language(@char).should eq 0
+          allow(@char).to receive(:fs3_languages) { lang }
+          expect(AbilityPointCounter.points_on_language(@char)).to eq 0
         end
       end
       
@@ -107,15 +107,15 @@ module AresMUSH
         it "should count abilities with more than one specialty" do
           action = [ FS3ActionSkill.new(specialties: [ "A", "B" ]), 
                      FS3ActionSkill.new(specialties: ["C", "D", "E"] ) ]
-          @char.stub(:fs3_action_skills) { action }
-          AbilityPointCounter.points_on_specialties(@char).should eq 3
+          allow(@char).to receive(:fs3_action_skills) { action }
+          expect(AbilityPointCounter.points_on_specialties(@char)).to eq 3
         end
         
         it "should not count first specialties" do
           action = [ FS3ActionSkill.new(specialties: [ "A" ]), 
                      FS3ActionSkill.new(specialties: [ "C" ] ) ]
-          @char.stub(:fs3_action_skills) { action }
-          AbilityPointCounter.points_on_specialties(@char).should eq 0
+          allow(@char).to receive(:fs3_action_skills) { action }
+          expect(AbilityPointCounter.points_on_specialties(@char)).to eq 0
         end
       end
       

--- a/plugins/fs3skills/specs/app_review_specs.rb
+++ b/plugins/fs3skills/specs/app_review_specs.rb
@@ -3,186 +3,186 @@ module AresMUSH
     describe FS3Skills do 
       
       before do
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end      
 
       describe :backgrounds do
         before do 
-          Global.stub(:read_config).with("fs3skills", "min_backgrounds") { 2 }
+          allow(Global).to receive(:read_config).with("fs3skills", "min_backgrounds") { 2 }
           @char = double
         end
         
         it "should error if too few bg skills" do
-          @char.stub(:fs3_background_skills) { [ FS3BackgroundSkill.new() ] }
+          allow(@char).to receive(:fs3_background_skills) { [ FS3BackgroundSkill.new() ] }
           review = FS3Skills.backgrounds_review(@char)
-          review.should eq "fs3skills.backgrounds_added                        chargen.not_enough"
+          expect(review).to eq "fs3skills.backgrounds_added                        chargen.not_enough"
         end
         
         it "should be OK if enough bg skills" do
-          @char.stub(:fs3_background_skills) { [ FS3BackgroundSkill.new(), FS3BackgroundSkill.new() ] }
+          allow(@char).to receive(:fs3_background_skills) { [ FS3BackgroundSkill.new(), FS3BackgroundSkill.new() ] }
           review = FS3Skills.backgrounds_review(@char)
-          review.should eq "fs3skills.backgrounds_added                        chargen.ok"
+          expect(review).to eq "fs3skills.backgrounds_added                        chargen.ok"
         end
       end
       
       describe :ability_rating_check do
         before do 
-          Global.stub(:read_config).with("fs3skills", "max_skills_at_or_above") { { 5 => 2, 7 => 1 } }
-          Global.stub(:read_config).with("fs3skills", "max_attrs_at_or_above") { { 4 => 2, 5 => 1 } }
-          Global.stub(:read_config).with("fs3skills", "max_points_on_attrs") { 14 }
-          Global.stub(:read_config).with("fs3skills", "max_points_on_action") { 20 }
+          allow(Global).to receive(:read_config).with("fs3skills", "max_skills_at_or_above") { { 5 => 2, 7 => 1 } }
+          allow(Global).to receive(:read_config).with("fs3skills", "max_attrs_at_or_above") { { 4 => 2, 5 => 1 } }
+          allow(Global).to receive(:read_config).with("fs3skills", "max_points_on_attrs") { 14 }
+          allow(Global).to receive(:read_config).with("fs3skills", "max_points_on_action") { 20 }
           @char = double
         end
         
         it "should error if too many skills above 6" do
-          @char.stub(:fs3_attributes) { [] }
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7), 
+          allow(@char).to receive(:fs3_attributes) { [] }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7), 
                                              FS3ActionSkill.new(rating: 8) ] }
           review = FS3Skills.ability_rating_review(@char)
-          review.should eq "fs3skills.ability_ratings_check%r%Tfs3skills.action_skills_above"
+          expect(review).to eq "fs3skills.ability_ratings_check%r%Tfs3skills.action_skills_above"
         end
 
         it "should error if too many skills above 4" do
-          @char.stub(:fs3_attributes) { [] }
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7),
+          allow(@char).to receive(:fs3_attributes) { [] }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7),
                                              FS3ActionSkill.new(rating: 5),
                                              FS3ActionSkill.new(rating: 5) ] }
           review = FS3Skills.ability_rating_review(@char)
-          review.should eq "fs3skills.ability_ratings_check%r%Tfs3skills.action_skills_above"
+          expect(review).to eq "fs3skills.ability_ratings_check%r%Tfs3skills.action_skills_above"
         end
         
         it "should error if too many points on attrs" do
-          @char.stub(:fs3_action_skills) { [] }
-          @char.stub(:fs3_attributes) { [ FS3Attribute.new(rating: 3),
+          allow(@char).to receive(:fs3_action_skills) { [] }
+          allow(@char).to receive(:fs3_attributes) { [ FS3Attribute.new(rating: 3),
                                              FS3Attribute.new(rating: 4),
                                              FS3Attribute.new(rating: 3),
                                              FS3Attribute.new(rating: 3),
                                              FS3Attribute.new(rating: 4),
                                              FS3Attribute.new(rating: 3) ] }
           review = FS3Skills.ability_rating_review(@char)
-          review.should eq "fs3skills.ability_ratings_check%r%Tfs3skills.too_many_attributes"
+          expect(review).to eq "fs3skills.ability_ratings_check%r%Tfs3skills.too_many_attributes"
         end
         
         it "should error if too many points on action skills" do
-          @char.stub(:fs3_attributes) { [] }
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7),
+          allow(@char).to receive(:fs3_attributes) { [] }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7),
                                              FS3ActionSkill.new(rating: 5),
                                              FS3ActionSkill.new(rating: 4),
                                              FS3ActionSkill.new(rating: 4),
                                              FS3ActionSkill.new(rating: 4),
                                              FS3ActionSkill.new(rating: 4) ] }
           review = FS3Skills.ability_rating_review(@char)
-          review.should eq "fs3skills.ability_ratings_check%r%Tfs3skills.too_many_action_skills"
+          expect(review).to eq "fs3skills.ability_ratings_check%r%Tfs3skills.too_many_action_skills"
         end
         
         it "should error if too many attrs above 3" do
-          @char.stub(:fs3_action_skills) { [] }
-          @char.stub(:fs3_attributes) { [ FS3Attribute.new(rating: 4),
+          allow(@char).to receive(:fs3_action_skills) { [] }
+          allow(@char).to receive(:fs3_attributes) { [ FS3Attribute.new(rating: 4),
                                              FS3Attribute.new(rating: 4),
                                              FS3Attribute.new(rating: 5) ] }
           review = FS3Skills.ability_rating_review(@char)
-          review.should eq "fs3skills.ability_ratings_check%r%Tfs3skills.attributes_above"
+          expect(review).to eq "fs3skills.ability_ratings_check%r%Tfs3skills.attributes_above"
         end
         
         it "should error if too many attrs above 4" do
-          @char.stub(:fs3_action_skills) { [] }
-          @char.stub(:fs3_attributes) { [ FS3Attribute.new(rating: 5),
+          allow(@char).to receive(:fs3_action_skills) { [] }
+          allow(@char).to receive(:fs3_attributes) { [ FS3Attribute.new(rating: 5),
                                              FS3Attribute.new(rating: 5) ] }
           review = FS3Skills.ability_rating_review(@char)
-          review.should eq "fs3skills.ability_ratings_check%r%Tfs3skills.attributes_above"
+          expect(review).to eq "fs3skills.ability_ratings_check%r%Tfs3skills.attributes_above"
         end
         
         it "should be OK if not too many high abilities" do
-          @char.stub(:fs3_attributes) { [ FS3Attribute.new(rating: 3),
+          allow(@char).to receive(:fs3_attributes) { [ FS3Attribute.new(rating: 3),
                                              FS3Attribute.new(rating: 4),
                                              FS3Attribute.new(rating: 2) ] }
-         @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7),
+         allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(rating: 7),
                                             FS3ActionSkill.new(rating: 4),
                                             FS3ActionSkill.new(rating: 3) ] }
           review = FS3Skills.ability_rating_review(@char)
-          review.should eq "fs3skills.ability_ratings_check                    chargen.ok"
+          expect(review).to eq "fs3skills.ability_ratings_check                    chargen.ok"
         end
       end
       
       
       describe :starting_language_review do
         before do 
-          Global.stub(:read_config).with("fs3skills", "starting_languages") { ["English", "German"] }
+          allow(Global).to receive(:read_config).with("fs3skills", "starting_languages") { ["English", "German"] }
           @char = double
         end
 
         it "should warn if missing a starting language" do
-          FS3Skills.stub(:ability_rating).with(@char, "English") { 3 }
-          FS3Skills.stub(:ability_rating).with(@char, "German") { 0 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "English") { 3 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "German") { 0 }
           review = FS3Skills.starting_language_review(@char)
-          review.should eq "fs3skills.language_check                           chargen.are_you_sure"
+          expect(review).to eq "fs3skills.language_check                           chargen.are_you_sure"
         end
         
         it "should be OK if all languages present" do
-          FS3Skills.stub(:ability_rating).with(@char, "English") { 3 }
-          FS3Skills.stub(:ability_rating).with(@char, "German") { 3 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "English") { 3 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "German") { 3 }
           review = FS3Skills.starting_language_review(@char)
-          review.should eq "fs3skills.language_check                           chargen.ok"
+          expect(review).to eq "fs3skills.language_check                           chargen.ok"
         end
       end
 
       describe :starting_skills_check do
         before do 
           @char = double
-          @char.stub(:fs3_action_skills) { [] }
-          StartingSkills.stub(:get_skills_for_char) { { "A" => 2, "B" => 3 }}
-          StartingSkills.stub(:get_specialties_for_char) { { "A" => [ "X" ] }}
-          FS3Skills.stub(:ability_rating).with(@char, "A") { 3 }
-          FS3Skills.stub(:ability_rating).with(@char, "B") { 3 }
-          FS3Skills.stub(:action_skill_config) { {} }
+          allow(@char).to receive(:fs3_action_skills) { [] }
+          allow(StartingSkills).to receive(:get_skills_for_char) { { "A" => 2, "B" => 3 }}
+          allow(StartingSkills).to receive(:get_specialties_for_char) { { "A" => [ "X" ] }}
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "A") { 3 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "B") { 3 }
+          allow(FS3Skills).to receive(:action_skill_config) { {} }
         end
 
         it "should warn if missing a starting skill" do
-          FS3Skills.stub(:ability_rating).with(@char, "B") { 0 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "B") { 0 }
           review = FS3Skills.starting_skills_check(@char)
-          review.should eq "fs3skills.starting_skills_check%r%Tfs3skills.missing_starting_skill"
+          expect(review).to eq "fs3skills.starting_skills_check%r%Tfs3skills.missing_starting_skill"
         end
         
         it "should be OK if all skills present" do
           review = FS3Skills.starting_skills_check(@char)
-          review.should eq "fs3skills.starting_skills_check                    chargen.ok"
+          expect(review).to eq "fs3skills.starting_skills_check                    chargen.ok"
         end
         
         it "should warn if missing a required specialty and over amateur" do
           config = { "specialties" => [ "A" ] }
-          FS3Skills.stub(:action_skill_config) { config }
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(name: "Firearms", rating: 3)] }
+          allow(FS3Skills).to receive(:action_skill_config) { config }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(name: "Firearms", rating: 3)] }
           review = FS3Skills.starting_skills_check(@char)
-          review.should eq "fs3skills.starting_skills_check%r%Tfs3skills.missing_specialty"
+          expect(review).to eq "fs3skills.starting_skills_check%r%Tfs3skills.missing_specialty"
         end
         
         it "should warn if missing a required specialty and under amateur" do
           config = { "specialties" => [ "A" ] }
-          FS3Skills.stub(:action_skill_config) { config }
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(name: "Firearms", rating: 2)] }
+          allow(FS3Skills).to receive(:action_skill_config) { config }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(name: "Firearms", rating: 2)] }
           review = FS3Skills.starting_skills_check(@char)
-          review.should eq "fs3skills.starting_skills_check                    chargen.ok"
+          expect(review).to eq "fs3skills.starting_skills_check                    chargen.ok"
         end
         
         it "should be OK if specialty present" do
           config = { "specialties" => [ "A" ] }
-          FS3Skills.stub(:action_skill_config) { config }
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(name: "Firearms", specialties: [ "X" ])] }
+          allow(FS3Skills).to receive(:action_skill_config) { config }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(name: "Firearms", specialties: [ "X" ])] }
           review = FS3Skills.starting_skills_check(@char)
-          review.should eq "fs3skills.starting_skills_check                    chargen.ok"
+          expect(review).to eq "fs3skills.starting_skills_check                    chargen.ok"
         end
         
         it "should warn if missing group specialty" do
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(name: "A", rating: 3)] }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(name: "A", rating: 3)] }
           review = FS3Skills.starting_skills_check(@char)
-          review.should eq "fs3skills.starting_skills_check%r%Tfs3skills.missing_group_specialty"
+          expect(review).to eq "fs3skills.starting_skills_check%r%Tfs3skills.missing_group_specialty"
         end
 
         it "should not warn if group specialty present" do
           skill = FS3ActionSkill.new(name: "A", rating: 3, specialties: [ 'X' ])
-          @char.stub(:fs3_action_skills) { [ skill ] }
+          allow(@char).to receive(:fs3_action_skills) { [ skill ] }
           review = FS3Skills.starting_skills_check(@char)
-          review.should eq "fs3skills.starting_skills_check                    chargen.ok"
+          expect(review).to eq "fs3skills.starting_skills_check                    chargen.ok"
         end
       end
       
@@ -190,45 +190,45 @@ module AresMUSH
       describe :unusual_skills_check do
         before do 
           @char = double
-          @char.stub(:fs3_background_skills) { [] }
-          @char.stub(:fs3_action_skills) { [] }
-          @char.stub(:fs3_languages) { [] }
-          Global.stub(:read_config).with("fs3skills", "unusual_skills") { [ "A" ] }
+          allow(@char).to receive(:fs3_background_skills) { [] }
+          allow(@char).to receive(:fs3_action_skills) { [] }
+          allow(@char).to receive(:fs3_languages) { [] }
+          allow(Global).to receive(:read_config).with("fs3skills", "unusual_skills") { [ "A" ] }
         end
 
         it "should warn if char has an unusual action skill above everyman" do
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(name: "A", rating: 2) ] }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(name: "A", rating: 2) ] }
           review = FS3Skills.unusual_skills_check(@char)
-          review.should eq "fs3skills.unusual_abilities_check%r%Tfs3skills.unusual_skill"
+          expect(review).to eq "fs3skills.unusual_abilities_check%r%Tfs3skills.unusual_skill"
         end
 
         it "should not warn if char has an unusual action skill at everyman" do
-          @char.stub(:fs3_action_skills) { [ FS3ActionSkill.new(name: "A", rating: 1) ] }
+          allow(@char).to receive(:fs3_action_skills) { [ FS3ActionSkill.new(name: "A", rating: 1) ] }
           review = FS3Skills.unusual_skills_check(@char)
-          review.should eq "fs3skills.unusual_abilities_check                  chargen.ok"
+          expect(review).to eq "fs3skills.unusual_abilities_check                  chargen.ok"
         end
         
         it "should warn if char has an unusual background skill" do
-          @char.stub(:fs3_background_skills) { [ FS3BackgroundSkill.new(name: "A", rating: 1) ] }
+          allow(@char).to receive(:fs3_background_skills) { [ FS3BackgroundSkill.new(name: "A", rating: 1) ] }
           review = FS3Skills.unusual_skills_check(@char)
-          review.should eq "fs3skills.unusual_abilities_check%r%Tfs3skills.unusual_skill"
+          expect(review).to eq "fs3skills.unusual_abilities_check%r%Tfs3skills.unusual_skill"
         end
         
         it "should warn if char has an unusual language skill" do
-          @char.stub(:fs3_languages) { [ FS3Language.new(name: "A", rating: 1) ] }
+          allow(@char).to receive(:fs3_languages) { [ FS3Language.new(name: "A", rating: 1) ] }
           review = FS3Skills.unusual_skills_check(@char)
-          review.should eq "fs3skills.unusual_abilities_check%r%Tfs3skills.unusual_skill"
+          expect(review).to eq "fs3skills.unusual_abilities_check%r%Tfs3skills.unusual_skill"
         end
         
         it "should warn if char has a high background skill" do
-          @char.stub(:fs3_background_skills) { [ FS3BackgroundSkill.new(name: "B", rating: 2)]}
+          allow(@char).to receive(:fs3_background_skills) { [ FS3BackgroundSkill.new(name: "B", rating: 2)]}
           review = FS3Skills.unusual_skills_check(@char)
-          review.should eq "fs3skills.unusual_abilities_check%r%Tfs3skills.high_bg"
+          expect(review).to eq "fs3skills.unusual_abilities_check%r%Tfs3skills.high_bg"
         end
         
         it "should be OK if no unusual skills present" do
           review = FS3Skills.unusual_skills_check(@char)
-          review.should eq "fs3skills.unusual_abilities_check                  chargen.ok"
+          expect(review).to eq "fs3skills.unusual_abilities_check                  chargen.ok"
         end
         
       end

--- a/plugins/fs3skills/specs/chargen_specs.rb
+++ b/plugins/fs3skills/specs/chargen_specs.rb
@@ -3,87 +3,87 @@ module AresMUSH
     describe FS3Skills do
 
       before do
-        Global.stub(:read_config).with("fs3skills", "max_skill_rating") { 7 }
-        Global.stub(:read_config).with("fs3skills", "max_attr_rating") { 4 }
-        FS3Skills.stub(:attr_names) { [ "Brawn", "Mind" ] }
-        FS3Skills.stub(:action_skill_names) { [ "Firearms", "Demolitions" ] }
-        FS3Skills.stub(:advantage_names) { [ "Rank" ] }
-        FS3Skills.stub(:language_names) { [ "English", "Spanish" ] }
-        Global.stub(:read_config).with("fs3skills", "allow_unskilled_action_skills") { false }
-        SpecHelpers.stub_translate_for_testing
+        allow(Global).to receive(:read_config).with("fs3skills", "max_skill_rating") { 7 }
+        allow(Global).to receive(:read_config).with("fs3skills", "max_attr_rating") { 4 }
+        allow(FS3Skills).to receive(:attr_names) { [ "Brawn", "Mind" ] }
+        allow(FS3Skills).to receive(:action_skill_names) { [ "Firearms", "Demolitions" ] }
+        allow(FS3Skills).to receive(:advantage_names) { [ "Rank" ] }
+        allow(FS3Skills).to receive(:language_names) { [ "English", "Spanish" ] }
+        allow(Global).to receive(:read_config).with("fs3skills", "allow_unskilled_action_skills") { false }
+        stub_translate_for_testing
       end
       
       describe :check_ability_name do
         it "should not allow funky chars" do
           # Because it will mess up the +/- modifier parsing
-          FS3Skills.check_ability_name("X+Y").should eq "fs3skills.no_special_characters"
-          FS3Skills.check_ability_name("X-Y").should eq "fs3skills.no_special_characters"
-          FS3Skills.check_ability_name("X=Y").should eq "fs3skills.no_special_characters"
-          FS3Skills.check_ability_name("X,Y").should eq "fs3skills.no_special_characters"
+          expect(FS3Skills.check_ability_name("X+Y")).to eq "fs3skills.no_special_characters"
+          expect(FS3Skills.check_ability_name("X-Y")).to eq "fs3skills.no_special_characters"
+          expect(FS3Skills.check_ability_name("X=Y")).to eq "fs3skills.no_special_characters"
+          expect(FS3Skills.check_ability_name("X,Y")).to eq "fs3skills.no_special_characters"
           
           # For aesthetic reasons
-          FS3Skills.check_ability_name("X:.[]|Y").should eq "fs3skills.no_special_characters"
+          expect(FS3Skills.check_ability_name("X:.[]|Y")).to eq "fs3skills.no_special_characters"
         end
         
         it "should allow spaces and underlines" do
-          FS3Skills.check_ability_name("X Y").should be_nil
-          FS3Skills.check_ability_name("X_Y").should be_nil
+          expect(FS3Skills.check_ability_name("X Y")).to be_nil
+          expect(FS3Skills.check_ability_name("X_Y")).to be_nil
         end
       end
       
       describe :check_rating do
         it "should error if below min ratings" do
-          FS3Skills.check_rating("Brawn", 0).should eq "fs3skills.min_rating_is"
-          FS3Skills.check_rating("Firearms", -1).should eq "fs3skills.min_rating_is"
-          FS3Skills.check_rating("English", -1).should eq "fs3skills.min_rating_is"
-          FS3Skills.check_rating("Basketweaving", -1).should eq "fs3skills.min_rating_is"
+          expect(FS3Skills.check_rating("Brawn", 0)).to eq "fs3skills.min_rating_is"
+          expect(FS3Skills.check_rating("Firearms", -1)).to eq "fs3skills.min_rating_is"
+          expect(FS3Skills.check_rating("English", -1)).to eq "fs3skills.min_rating_is"
+          expect(FS3Skills.check_rating("Basketweaving", -1)).to eq "fs3skills.min_rating_is"
         end
         
         it "should allow unskilled for min rating if configured" do
-          Global.stub(:read_config).with("fs3skills", "allow_unskilled_action_skills") { true }
-          FS3Skills.check_rating("Brawn", 0).should eq "fs3skills.min_rating_is"
+          allow(Global).to receive(:read_config).with("fs3skills", "allow_unskilled_action_skills") { true }
+          expect(FS3Skills.check_rating("Brawn", 0)).to eq "fs3skills.min_rating_is"
         end
         
         it "should allow min ratings" do
-          FS3Skills.check_rating("Brawn", 1).should be_nil
-          FS3Skills.check_rating("Firearms", 1).should be_nil
-          FS3Skills.check_rating("English", 0).should be_nil
-          FS3Skills.check_rating("Basketweaving", 0).should be_nil
+          expect(FS3Skills.check_rating("Brawn", 1)).to be_nil
+          expect(FS3Skills.check_rating("Firearms", 1)).to be_nil
+          expect(FS3Skills.check_rating("English", 0)).to be_nil
+          expect(FS3Skills.check_rating("Basketweaving", 0)).to be_nil
         end
 
         it "should allow max ratings" do
-          FS3Skills.check_rating("Brawn", 4).should be_nil
-          FS3Skills.check_rating("Firearms", 7).should be_nil
-          FS3Skills.check_rating("English", 3).should be_nil
-          FS3Skills.check_rating("Basketweaving", 3).should be_nil
+          expect(FS3Skills.check_rating("Brawn", 4)).to be_nil
+          expect(FS3Skills.check_rating("Firearms", 7)).to be_nil
+          expect(FS3Skills.check_rating("English", 3)).to be_nil
+          expect(FS3Skills.check_rating("Basketweaving", 3)).to be_nil
         end
         
         it "should error if above max ratings" do
-          FS3Skills.check_rating("Brawn", 5).should eq "fs3skills.max_rating_is"
-          FS3Skills.check_rating("Firearms", 8).should eq "fs3skills.max_rating_is"
-          FS3Skills.check_rating("English", 4).should eq "fs3skills.max_rating_is"
-          FS3Skills.check_rating("Basketweaving", 4).should eq "fs3skills.max_rating_is"
+          expect(FS3Skills.check_rating("Brawn", 5)).to eq "fs3skills.max_rating_is"
+          expect(FS3Skills.check_rating("Firearms", 8)).to eq "fs3skills.max_rating_is"
+          expect(FS3Skills.check_rating("English", 4)).to eq "fs3skills.max_rating_is"
+          expect(FS3Skills.check_rating("Basketweaving", 4)).to eq "fs3skills.max_rating_is"
         end
         
         it "should allow max action skill rating to be configurable" do
-          Global.stub(:read_config).with("fs3skills", "max_skill_rating") { 5 }
-          FS3Skills.check_rating("Firearms", 5).should be_nil
-          FS3Skills.check_rating("Firearms", 6).should eq "fs3skills.max_rating_is"
+          allow(Global).to receive(:read_config).with("fs3skills", "max_skill_rating") { 5 }
+          expect(FS3Skills.check_rating("Firearms", 5)).to be_nil
+          expect(FS3Skills.check_rating("Firearms", 6)).to eq "fs3skills.max_rating_is"
         end
       end
       
       describe :set_ability do 
         before do
-          FS3Skills.stub(:check_rating) { nil }
-          FS3Skills.stub(:check_ability_name) { nil }
+          allow(FS3Skills).to receive(:check_rating) { nil }
+          allow(FS3Skills).to receive(:check_ability_name) { nil }
           
           @client = double
           @char = double
         end
           
         it "should error if abiliy name invalid" do 
-          FS3Skills.stub(:check_ability_name) { "an error" }
-          @client.should_receive(:emit_failure).with("an error")
+          allow(FS3Skills).to receive(:check_ability_name) { "an error" }
+          expect(@client).to receive(:emit_failure).with("an error")
           FS3Skills.set_ability(@client, @char, "Firearms", 4)
         end
         
@@ -91,36 +91,36 @@ module AresMUSH
         context "success" do
           before do
             @ability = double
-            @char.stub(:id) { 1 }
-            FS3Skills.stub(:find_ability).with(@char, "Firearms") { @ability }
-            @ability.stub(:update)
-            @client.stub(:emit_success)
-            @char.stub(:name) { "Bob" }
-            @ability.stub(:rating_name) { "X" }
+            allow(@char).to receive(:id) { 1 }
+            allow(FS3Skills).to receive(:find_ability).with(@char, "Firearms") { @ability }
+            allow(@ability).to receive(:update)
+            allow(@client).to receive(:emit_success)
+            allow(@char).to receive(:name) { "Bob" }
+            allow(@ability).to receive(:rating_name) { "X" }
           end
         
           it "should emit one message for changing your own ability" do
-            @client.stub(:char_id) { 1 }
-            @client.should_receive(:emit_success).with("fs3skills.action_set")
+            allow(@client).to receive(:char_id) { 1 }
+            expect(@client).to receive(:emit_success).with("fs3skills.action_set")
             FS3Skills.set_ability(@client, @char, "Firearms", 4)
           end
         
           it "should emit a different message for changing someone else's ability" do
-            @client.stub(:char_id) { 2 }
-            @client.should_receive(:emit_success).with("fs3skills.admin_ability_set")
+            allow(@client).to receive(:char_id) { 2 }
+            expect(@client).to receive(:emit_success).with("fs3skills.admin_ability_set")
             FS3Skills.set_ability(@client, @char, "Firearms", 4)
           end
           
           it "should update an existing ability" do
-            @client.stub(:char_id) { 2 }
-            @ability.should_receive(:update).with(rating: 4)
+            allow(@client).to receive(:char_id) { 2 }
+            expect(@ability).to receive(:update).with(rating: 4)
             FS3Skills.set_ability(@client, @char, "Firearms", 4)
           end
 
           it "should create a new ability" do
-            @client.stub(:char_id) { 2 }
-            FS3Skills.stub(:find_ability).with(@char, "Firearms") { nil }
-            FS3ActionSkill.should_receive(:create).with(character: @char, name: "Firearms", rating: 4) { @ability }
+            allow(@client).to receive(:char_id) { 2 }
+            allow(FS3Skills).to receive(:find_ability).with(@char, "Firearms") { nil }
+            expect(FS3ActionSkill).to receive(:create).with(character: @char, name: "Firearms", rating: 4) { @ability }
             FS3Skills.set_ability(@client, @char, "Firearms", 4)
           end
         end

--- a/plugins/fs3skills/specs/luck_specs.rb
+++ b/plugins/fs3skills/specs/luck_specs.rb
@@ -3,7 +3,7 @@ module AresMUSH
     describe FS3Skills do
 
       before do
-        Global.stub(:read_config).with("fs3skills", "max_luck") { 3 }
+        allow(Global).to receive(:read_config).with("fs3skills", "max_luck") { 3 }
       end
       
       describe :award_luck do
@@ -12,12 +12,12 @@ module AresMUSH
         end
         
         it "should add luck" do
-          @char.should_receive(:update).with(fs3_luck: 2.0) {}
+          expect(@char).to receive(:update).with(fs3_luck: 2.0) {}
           @char.award_luck(1)
         end
 
         it "should not go over the cap" do
-          @char.should_receive(:update).with(fs3_luck: 3.0) {}
+          expect(@char).to receive(:update).with(fs3_luck: 3.0) {}
           @char.award_luck(5)
         end
       end
@@ -28,12 +28,12 @@ module AresMUSH
         end
         
         it "should spend luck" do
-          @char.should_receive(:update).with(fs3_luck: 1.0)
+          expect(@char).to receive(:update).with(fs3_luck: 1.0)
           @char.spend_luck(1)
         end
 
         it "should not go below zero" do
-          @char.should_receive(:update).with(fs3_luck: 0)
+          expect(@char).to receive(:update).with(fs3_luck: 0)
           @char.spend_luck(5)
         end
       end
@@ -45,7 +45,7 @@ module AresMUSH
         end
         
         it "should return luck" do
-          @char.luck.should eq 2
+          expect(@char.luck).to eq 2
         end
       end
     end

--- a/plugins/fs3skills/specs/parse_roll_specs.rb
+++ b/plugins/fs3skills/specs/parse_roll_specs.rb
@@ -3,8 +3,8 @@ module AresMUSH
     describe FS3Skills do
 
       before do
-        Global.stub(:read_config).with("fs3skills", "max_luck") { 3 }
-        SpecHelpers.stub_translate_for_testing
+        allow(Global).to receive(:read_config).with("fs3skills", "max_luck") { 3 }
+        stub_translate_for_testing
       end
 
       describe :parse_and_roll do
@@ -14,21 +14,21 @@ module AresMUSH
         end
   
         it "should emit failure and return nil if it can't parse the roll" do
-          FS3Skills.stub(:parse_roll_params) { nil }
-          @client.should_receive(:emit_failure).with 'fs3skills.unknown_roll_params'
-          FS3Skills.parse_and_roll(@client, @char, "x").should be_nil
+          allow(FS3Skills).to receive(:parse_roll_params) { nil }
+          expect(@client).to receive(:emit_failure).with 'fs3skills.unknown_roll_params'
+          expect(FS3Skills.parse_and_roll(@client, @char, "x")).to be_nil
         end
   
         it "should return a die result for a plain number" do
           # Note - automatically factors in a default linked attr
-          FS3Skills.stub(:roll_dice).with(4) { [1, 2, 3, 4, 5] }
-          FS3Skills.parse_and_roll(@client, @char, "2").should eq [1, 2, 3, 4, 5]
+          allow(FS3Skills).to receive(:roll_dice).with(4) { [1, 2, 3, 4, 5] }
+          expect(FS3Skills.parse_and_roll(@client, @char, "2")).to eq [1, 2, 3, 4, 5]
         end
   
         it "should parse results and roll the ability for any other string" do
-          FS3Skills.stub(:parse_roll_params) { "x" }
-          FS3Skills.stub(:roll_ability).with(@client, @char, "x") { [1, 2, 3]}
-          FS3Skills.parse_and_roll(@client, @char, "abc").should eq [1, 2, 3]
+          allow(FS3Skills).to receive(:parse_roll_params) { "x" }
+          allow(FS3Skills).to receive(:roll_ability).with(@client, @char, "x") { [1, 2, 3]}
+          expect(FS3Skills.parse_and_roll(@client, @char, "abc")).to eq [1, 2, 3]
         end
       end
 
@@ -80,131 +80,131 @@ module AresMUSH
         
         it "should handle bad string with negative ruling attr" do
           params = FS3Skills.parse_roll_params("A-B+2")
-          params.should be_nil
+          expect(params).to be_nil
         end
 
         it "should handle bad string with a non-digit modifier" do
           params = FS3Skills.parse_roll_params("A+B+C")
-          params.should be_nil
+          expect(params).to be_nil
         end
         
         it "should handle bad string with too many params" do
           params = FS3Skills.parse_roll_params("A+B+2+D")
-          params.should be_nil
+          expect(params).to be_nil
         end
       end
       
       describe :dice_to_roll_for_ability do
         before do
           @char = double
-          @char.stub(:name) { "Nemo" }
+          allow(@char).to receive(:name) { "Nemo" }
 
-          FS3Skills.stub(:get_ability_type).with("Firearms") { :action }
-          FS3Skills.stub(:get_ability_type).with("Brawn") { :attribute }
-          FS3Skills.stub(:get_ability_type).with("Reflexes") { :attribute }
-          FS3Skills.stub(:get_ability_type).with("English") { :language }
-          FS3Skills.stub(:get_ability_type).with("Basketweaving") { :background }
-          FS3Skills.stub(:get_ability_type).with("Untrained") { :background }
-          FS3Skills.stub(:get_ability_type).with(nil) { :background }
+          allow(FS3Skills).to receive(:get_ability_type).with("Firearms") { :action }
+          allow(FS3Skills).to receive(:get_ability_type).with("Brawn") { :attribute }
+          allow(FS3Skills).to receive(:get_ability_type).with("Reflexes") { :attribute }
+          allow(FS3Skills).to receive(:get_ability_type).with("English") { :language }
+          allow(FS3Skills).to receive(:get_ability_type).with("Basketweaving") { :background }
+          allow(FS3Skills).to receive(:get_ability_type).with("Untrained") { :background }
+          allow(FS3Skills).to receive(:get_ability_type).with(nil) { :background }
           
-          FS3Skills.stub(:ability_rating).with(@char, "Untrained") { 0 }
-          FS3Skills.stub(:ability_rating).with(@char, "Firearms") { 1 }
-          FS3Skills.stub(:ability_rating).with(@char, "Basketweaving") { 2 }
-          FS3Skills.stub(:ability_rating).with(@char, "English") { 3 }
-          FS3Skills.stub(:ability_rating).with(@char, "Brawn") { 4 }
-          FS3Skills.stub(:ability_rating).with(@char, "Reflexes") { 2 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "Untrained") { 0 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "Firearms") { 1 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "Basketweaving") { 2 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "English") { 3 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "Brawn") { 4 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "Reflexes") { 2 }
           
-          FS3Skills.stub(:get_linked_attr).with("Untrained") { "Brawn" }
-          FS3Skills.stub(:get_linked_attr).with("Firearms") { "Reflexes" }
-          FS3Skills.stub(:get_linked_attr).with("Brawn") { nil }
-          FS3Skills.stub(:get_linked_attr).with("Basketweaving") { "Reflexes" }
-          FS3Skills.stub(:get_linked_attr).with("English") { "Reflexes" }
+          allow(FS3Skills).to receive(:get_linked_attr).with("Untrained") { "Brawn" }
+          allow(FS3Skills).to receive(:get_linked_attr).with("Firearms") { "Reflexes" }
+          allow(FS3Skills).to receive(:get_linked_attr).with("Brawn") { nil }
+          allow(FS3Skills).to receive(:get_linked_attr).with("Basketweaving") { "Reflexes" }
+          allow(FS3Skills).to receive(:get_linked_attr).with("English") { "Reflexes" }
         end
       
         it "should roll ability alone" do
           roll_params = RollParams.new("Firearms")
           # Rolls Firearms + Reflexes 
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 3
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 3
         end
       
         it "should roll ability + a different ruling attr" do
           roll_params = RollParams.new("Firearms", 0, "Brawn")
           # Rolls Firearms + Brawn
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 5
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 5
         end
         
         it "should roll attr + ability" do
           roll_params = RollParams.new("Brawn", 0, "Firearms")
           # Rolls Brawn + Firearms
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 5
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 5
         end
 
         it "should roll attr + attr" do
           roll_params = RollParams.new("Brawn", 0, "Reflexes")
           # Rolls Brawn + Reflexes
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 6
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 6
         end
         
         it "should roll ability + ability" do
           roll_params = RollParams.new("Firearms", 0, "Firearms")
           # Rolls Firearms + Firearms
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 2
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 2
         end
         
         it "should roll twice a background skill" do 
           roll_params = RollParams.new("Basketweaving")
           # Rolls Basketweaving*2 + Reflexes
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 6
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 6
         end
         
         it "should roll twice a language skill" do 
           roll_params = RollParams.new("English")
           # Rolls English*2 + Reflexes
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 8
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 8
         end
         
         it "should roll ability + modifier" do
           roll_params = RollParams.new("Firearms", 1)
           # Rolls Firearms + Reflexes + 1
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 4
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 4
         end
       
         it "should roll ability - modifier" do
           roll_params = RollParams.new("Firearms", -1)
           # Rolls Firearms + Reflexes - 1 
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 2
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 2
         end
       
         it "should roll ability + ruling attr + modifier" do
           roll_params = RollParams.new("Firearms", 3, "Brawn")
           # Rolls Firearms + Brawn + 3 
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 8
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 8
         end
         
         it "should roll everyman for an attribute" do
           roll_params = RollParams.new("Brawn")
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 5
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 5
         end
         
         it "should roll everyman for nonexistant bg skill" do
           roll_params = RollParams.new("Untrained")
           # Rolls everyman (1) + Brawn
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 5
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 5
         end
         
         it "should roll zero for nonexistant lang skill" do
-          FS3Skills.stub(:ability_rating).with(@char, "English") { 0 }
+          allow(FS3Skills).to receive(:ability_rating).with(@char, "English") { 0 }
           roll_params = RollParams.new("English")
           # Rolls 0 + Reflexes
-          FS3Skills.dice_to_roll_for_ability(@char, roll_params).should eq 2
+          expect(FS3Skills.dice_to_roll_for_ability(@char, roll_params)).to eq 2
         end
         
       end
       
       def check_params(params, ability, modifier, linked_attr)
-        params.ability.should eq ability
-        params.modifier.should eq modifier
-        params.linked_attr.should eq linked_attr
+        expect(params.ability).to eq ability
+        expect(params.modifier).to eq modifier
+        expect(params.linked_attr).to eq linked_attr
       end
       
       

--- a/plugins/fs3skills/specs/ratings_specs.rb
+++ b/plugins/fs3skills/specs/ratings_specs.rb
@@ -3,10 +3,10 @@ module AresMUSH
     describe FS3Skills do
 
       before do
-        FS3Skills.stub(:attr_names) { [ "Brawn", "Mind" ] }
-        FS3Skills.stub(:action_skill_names) { [ "Firearms", "Demolitions" ] }
-        FS3Skills.stub(:language_names) { [ "English", "Spanish" ] }
-        FS3Skills.stub(:advantage_names) { [ "Rank", "Resources" ] }
+        allow(FS3Skills).to receive(:attr_names) { [ "Brawn", "Mind" ] }
+        allow(FS3Skills).to receive(:action_skill_names) { [ "Firearms", "Demolitions" ] }
+        allow(FS3Skills).to receive(:language_names) { [ "English", "Spanish" ] }
+        allow(FS3Skills).to receive(:advantage_names) { [ "Rank", "Resources" ] }
       end
       
       describe :ability_rating do
@@ -18,78 +18,78 @@ module AresMUSH
           @attrs = double
           @advantages = double
           
-          @advantages.stub(:find).with(name: "Resources") { [] }
-          @advantages.stub(:find).with(name: "Rank") { [ FS3Advantage.new(name: "Rank", rating: 3 ) ]}
+          allow(@advantages).to receive(:find).with(name: "Resources") { [] }
+          allow(@advantages).to receive(:find).with(name: "Rank") { [ FS3Advantage.new(name: "Rank", rating: 3 ) ]}
           
-          @languages.stub(:find).with(name: "Spanish") { [] }
-          @languages.stub(:find).with(name: "English") { [ FS3Language.new(name: "English", rating: 1 ) ] }
+          allow(@languages).to receive(:find).with(name: "Spanish") { [] }
+          allow(@languages).to receive(:find).with(name: "English") { [ FS3Language.new(name: "English", rating: 1 ) ] }
           
-          @action_skills.stub(:find).with(name: "Firearms") {[ FS3ActionSkill.new(name: "Firearms", rating: 2 )] }
-          @action_skills.stub(:find).with(name: "Demolitions") { [] }
+          allow(@action_skills).to receive(:find).with(name: "Firearms") {[ FS3ActionSkill.new(name: "Firearms", rating: 2 )] }
+          allow(@action_skills).to receive(:find).with(name: "Demolitions") { [] }
           
-          @bg_skills.stub(:find).with(name: "Basketweaving") { [ FS3BackgroundSkill.new(name: "Basketweaving", rating: 3 )] }
-          @bg_skills.stub(:find).with(name: "Art") { [] }
+          allow(@bg_skills).to receive(:find).with(name: "Basketweaving") { [ FS3BackgroundSkill.new(name: "Basketweaving", rating: 3 )] }
+          allow(@bg_skills).to receive(:find).with(name: "Art") { [] }
 
-          @attrs.stub(:find).with(name: "Brawn") { [ FS3Attribute.new(name: "Brawn", rating: 4 )] }
-          @attrs.stub(:find).with(name: "Mind") { [] }
+          allow(@attrs).to receive(:find).with(name: "Brawn") { [ FS3Attribute.new(name: "Brawn", rating: 4 )] }
+          allow(@attrs).to receive(:find).with(name: "Mind") { [] }
           
-          @char.stub(:fs3_languages) { @languages }
-          @char.stub(:fs3_attributes) { @attrs }
-          @char.stub(:fs3_action_skills) { @action_skills }
-          @char.stub(:fs3_background_skills) { @bg_skills }
-          @char.stub(:fs3_advantages) { @advantages }
+          allow(@char).to receive(:fs3_languages) { @languages }
+          allow(@char).to receive(:fs3_attributes) { @attrs }
+          allow(@char).to receive(:fs3_action_skills) { @action_skills }
+          allow(@char).to receive(:fs3_background_skills) { @bg_skills }
+          allow(@char).to receive(:fs3_advantages) { @advantages }
         end
         
         it "should get skills that exist" do
-          FS3Skills.ability_rating(@char, "English").should eq 1
-          FS3Skills.ability_rating(@char, "Firearms").should eq 2
-          FS3Skills.ability_rating(@char, "Basketweaving").should eq 3
-          FS3Skills.ability_rating(@char, "Brawn").should eq 4
-          FS3Skills.ability_rating(@char, "Rank").should eq 3
+          expect(FS3Skills.ability_rating(@char, "English")).to eq 1
+          expect(FS3Skills.ability_rating(@char, "Firearms")).to eq 2
+          expect(FS3Skills.ability_rating(@char, "Basketweaving")).to eq 3
+          expect(FS3Skills.ability_rating(@char, "Brawn")).to eq 4
+          expect(FS3Skills.ability_rating(@char, "Rank")).to eq 3
         end
         
         it "should get skills that don't exit" do
-          FS3Skills.ability_rating(@char, "Spanish").should eq 0
-          FS3Skills.ability_rating(@char, "Demolitions").should eq 0
-          FS3Skills.ability_rating(@char, "Mind").should eq 0
-          FS3Skills.ability_rating(@char, "Art").should eq 0
-          FS3Skills.ability_rating(@char, "Resources").should eq 0
+          expect(FS3Skills.ability_rating(@char, "Spanish")).to eq 0
+          expect(FS3Skills.ability_rating(@char, "Demolitions")).to eq 0
+          expect(FS3Skills.ability_rating(@char, "Mind")).to eq 0
+          expect(FS3Skills.ability_rating(@char, "Art")).to eq 0
+          expect(FS3Skills.ability_rating(@char, "Resources")).to eq 0
         end
         
         it "should not search background skills for an action skill" do
-          @bg_skills.stub(:find).with(name: "Demolitions") { [ FS3BackgroundSkill.new(name: "Demolitions", rating: 3 )] }
-          FS3Skills.ability_rating(@char, "Demolitions").should eq 0
+          allow(@bg_skills).to receive(:find).with(name: "Demolitions") { [ FS3BackgroundSkill.new(name: "Demolitions", rating: 3 )] }
+          expect(FS3Skills.ability_rating(@char, "Demolitions")).to eq 0
         end
         
         it "should not search background skills for a language" do
-          @bg_skills.stub(:find).with(name: "Spanish") { [ FS3BackgroundSkill.new(name: "Spanish", rating: 3 )] }
-          FS3Skills.ability_rating(@char, "Spanish").should eq 0
+          allow(@bg_skills).to receive(:find).with(name: "Spanish") { [ FS3BackgroundSkill.new(name: "Spanish", rating: 3 )] }
+          expect(FS3Skills.ability_rating(@char, "Spanish")).to eq 0
         end
       end
       
       describe :get_linked_attr do
         before do 
           skills = [ { "name" => "Firearms", "linked_attr" => "Brawn" } ]
-          Global.stub(:read_config).with("fs3skills", "default_linked_attr") { "Wits" }
-          Global.stub(:read_config).with("fs3skills", "action_skills") { skills }
+          allow(Global).to receive(:read_config).with("fs3skills", "default_linked_attr") { "Wits" }
+          allow(Global).to receive(:read_config).with("fs3skills", "action_skills") { skills }
           
         end
         
         it "should get linked for an action skill from the skill config" do
-          FS3Skills.get_linked_attr("Firearms").should eq "Brawn"
+          expect(FS3Skills.get_linked_attr("Firearms")).to eq "Brawn"
         end
 
         it "should return nothing for attribute" do
-          FS3Skills.get_linked_attr("Mind").should be_nil
+          expect(FS3Skills.get_linked_attr("Mind")).to be_nil
         end
         
         it "should default for langs and background skills" do
-          FS3Skills.get_linked_attr("Basketweaving").should eq "Wits"
-          FS3Skills.get_linked_attr("Spanish").should eq "Wits"
+          expect(FS3Skills.get_linked_attr("Basketweaving")).to eq "Wits"
+          expect(FS3Skills.get_linked_attr("Spanish")).to eq "Wits"
         end
         
         it "should default for advantages" do
-          FS3Skills.get_linked_attr("Rank").should eq "Wits"
+          expect(FS3Skills.get_linked_attr("Rank")).to eq "Wits"
         end
         
       end

--- a/plugins/fs3skills/specs/roll_opposed_specs.rb
+++ b/plugins/fs3skills/specs/roll_opposed_specs.rb
@@ -5,37 +5,37 @@ module AresMUSH
         it "should fail if the string is invalid" do
           handler = OpposedRollCmd.new(nil, Command.new("roll A vs B"), nil)
           handler.parse_args
-          handler.name1.should be_nil
-          handler.name2.should be_nil
-          handler.roll_str1.should be_nil
-          handler.roll_str2.should be_nil
+          expect(handler.name1).to be_nil
+          expect(handler.name2).to be_nil
+          expect(handler.roll_str1).to be_nil
+          expect(handler.roll_str2).to be_nil
         end
         
         it "should crack a PC roll vs a NPC number" do
           handler = OpposedRollCmd.new(nil, Command.new("roll A/1 vs 3"), nil)
           handler.parse_args
-          handler.name1.should eq "A"
-          handler.name2.should be_nil
-          handler.roll_str1.should eq "1"
-          handler.roll_str2.should eq "3"
+          expect(handler.name1).to eq "A"
+          expect(handler.name2).to be_nil
+          expect(handler.roll_str1).to eq "1"
+          expect(handler.roll_str2).to eq "3"
         end
         
         it "should crack a PC roll vs another PC" do
           handler = OpposedRollCmd.new(nil, Command.new("roll A/Firearms vs B/Melee"), nil)
           handler.parse_args
-          handler.name1.should eq "A"
-          handler.name2.should eq "B"
-          handler.roll_str1.should eq "Firearms"
-          handler.roll_str2.should eq "Melee"
+          expect(handler.name1).to eq "A"
+          expect(handler.name2).to eq "B"
+          expect(handler.roll_str1).to eq "Firearms"
+          expect(handler.roll_str2).to eq "Melee"
         end
         
         it "should crack skill names with spaces" do
           handler = OpposedRollCmd.new(nil, Command.new("roll A/Basket Weaving+2 vs B/Scuba Diving - 1"), nil)
           handler.parse_args
-          handler.name1.should eq "A"
-          handler.name2.should eq "B"
-          handler.roll_str1.should eq "Basket Weaving+2"
-          handler.roll_str2.should eq "Scuba Diving - 1"
+          expect(handler.name1).to eq "A"
+          expect(handler.name2).to eq "B"
+          expect(handler.roll_str1).to eq "Basket Weaving+2"
+          expect(handler.roll_str2).to eq "Scuba Diving - 1"
         end
         
       end

--- a/plugins/fs3skills/specs/roll_specs.rb
+++ b/plugins/fs3skills/specs/roll_specs.rb
@@ -3,66 +3,66 @@ module AresMUSH
     describe FS3Skills do
 
       before do
-        Global.stub(:read_config).with("fs3skills", "max_luck") { 3 }
-        Global.stub(:read_config).with("fs3skills", "roll_channel") { "FS3 Chan" }
+        allow(Global).to receive(:read_config).with("fs3skills", "max_luck") { 3 }
+        allow(Global).to receive(:read_config).with("fs3skills", "roll_channel") { "FS3 Chan" }
 
         # Note:  By seeding the random number generator, we can avoid the randomness.
         #   If you use Kernel.srand(22), the first 10 die rolls in tests will always be:  
         #      [6, 5, 5, 1, 5, 7, 7, 4, 5, 1]
         Kernel.srand 22
 
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
       
       describe :emit_results do
         before do
           @main_client = double
           @main_char = double
-          SpecHelpers.setup_mock_client(@main_client, @main_char)
+          setup_mock_client(@main_client, @main_char)
                   
           @room = double
-          @main_char.stub(:room) { @room }
-          @main_client.stub(:emit)
-          @room.stub(:emit)
+          allow(@main_char).to receive(:room) { @room }
+          allow(@main_client).to receive(:emit)
+          allow(@room).to receive(:emit)
         end
   
         context "private roll" do
           it "should emit to the client" do
-            @main_client.should_receive(:emit).with("test")
+            expect(@main_client).to receive(:emit).with("test")
             FS3Skills.emit_results("test", @main_client, @room, true)
           end
     
           it "should not emit to the room" do
-            @room.should_not_receive(:emit).with("test")
+            expect(@room).to_not receive(:emit).with("test")
             FS3Skills.emit_results("test", @main_client, @room, true)
           end
           
           it "should emit to the channel" do
-            Channels.should_not_receive(:send_to_channel).with("FS3 Chan", "test")
+            expect(Channels).to_not receive(:send_to_channel).with("FS3 Chan", "test")
             FS3Skills.emit_results("test", @main_client, @room, true)
           end
         end
   
         context "public roll" do
           before do
-            Channels.stub(:send_to_channel)
-            @room.stub(:scene) { nil }
+            allow(Channels).to receive(:send_to_channel)
+            allow(@room).to receive(:scene) { nil }
           end
           
           it "should emit to the room" do
-            @room.should_receive(:emit).with("test")
+            expect(@room).to receive(:emit).with("test")
             FS3Skills.emit_results("test", @main_client, @room, false)
           end
     
           it "should emit to the channel" do
-            Channels.should_receive(:send_to_channel).with("FS3 Chan", "test")
+            expect(Channels).to receive(:send_to_channel).with("FS3 Chan", "test")
             FS3Skills.emit_results("test", @main_client, @room, false)
           end
           
           it "should emit to the scene" do
             scene = double
-            @room.stub(:scene) { scene }
-            Scenes.should_receive(:add_to_scene).with(scene, "test")
+            allow(@room).to receive(:scene) { scene }
+            expect(Scenes).to receive(:add_to_scene).with(scene, "test")
             FS3Skills.emit_results("test", @main_client, @room, false)
           end
         end
@@ -73,41 +73,41 @@ module AresMUSH
         before do
           @client = double
           @char = double
-          @char.stub(:name) { "Nemo" }
+          allow(@char).to receive(:name) { "Nemo" }
         end
         
         it "should roll ability" do
           roll_params = RollParams.new("Firearms")
-          FS3Skills.should_receive(:dice_to_roll_for_ability).with(@char, roll_params) { 5 }
-          FS3Skills.roll_ability(@client, @char, roll_params).should eq [6, 5, 5, 1, 5]
+          expect(FS3Skills).to receive(:dice_to_roll_for_ability).with(@char, roll_params) { 5 }
+          expect(FS3Skills.roll_ability(@client, @char, roll_params)).to eq [6, 5, 5, 1, 5]
         end
       end
     
       describe :roll_dice do
         it "should roll the specified number of dice" do
-          FS3Skills.roll_dice(4).should eq [ 6, 5, 5, 1 ]
+          expect(FS3Skills.roll_dice(4)).to eq [ 6, 5, 5, 1 ]
         end
         
         it "should always roll 1 die even if asked for 0 or less" do
-          FS3Skills.roll_dice(0).should eq [6]
+          expect(FS3Skills.roll_dice(0)).to eq [6]
         end
         
         it "should not allow giant die rolls" do
-          FS3Skills.roll_dice(99).should eq [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8]
+          expect(FS3Skills.roll_dice(99)).to eq [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8]
         end
       end
     
       describe :get_success_level do
         it "should return number of successes if there are any" do
-          FS3Skills.get_success_level([7, 1, 3, 8]).should eq 2
+          expect(FS3Skills.get_success_level([7, 1, 3, 8])).to eq 2
         end
         
         it "should return a botch if there are more than two ones and no successes" do
-          FS3Skills.get_success_level([4, 1, 1, 1]).should eq -1
+          expect(FS3Skills.get_success_level([4, 1, 1, 1])).to eq -1
         end
         
         it "should return a failure if there are no successes but less than two ones." do
-          FS3Skills.get_success_level([4, 1, 3, 4]).should eq 0
+          expect(FS3Skills.get_success_level([4, 1, 3, 4])).to eq 0
         end
       end
       

--- a/plugins/fs3skills/specs/starting_skill_specs.rb
+++ b/plugins/fs3skills/specs/starting_skill_specs.rb
@@ -3,7 +3,7 @@ module AresMUSH
     describe FS3Skills do 
       
       before do
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
       
       describe :get_skills_for_char do
@@ -14,60 +14,60 @@ module AresMUSH
             "Position" => { "Pilot" => { "skills" => { "C" => 4 } } },
             "Faction" => { "Navy" => { "skills" => { "C" => 2 } } }
           }
-          Global.stub(:read_config).with("fs3skills", "starting_skills") { starting_skills }
-          Global.stub(:read_config).with("fs3skills", "attributes") { [ ] }
-          Global.stub(:read_config).with("fs3skills", "action_skills") { [ ] }
+          allow(Global).to receive(:read_config).with("fs3skills", "starting_skills") { starting_skills }
+          allow(Global).to receive(:read_config).with("fs3skills", "attributes") { [ ] }
+          allow(Global).to receive(:read_config).with("fs3skills", "action_skills") { [ ] }
           
-          Global.stub(:read_config).with("fs3skills", "allow_unskilled_action_skills") { true }
+          allow(Global).to receive(:read_config).with("fs3skills", "allow_unskilled_action_skills") { true }
           
           @char = double
         end
         
         it "should include Everyone skills" do
-          @char.stub(:group).with("Position") { "Other" }
-          @char.stub(:group).with("Faction") { "Other" }
+          allow(@char).to receive(:group).with("Position") { "Other" }
+          allow(@char).to receive(:group).with("Faction") { "Other" }
           skills = { "A" => 2, "B" => 3 }
-          StartingSkills.get_skills_for_char(@char).should eq skills
+          expect(StartingSkills.get_skills_for_char(@char)).to eq skills
         end
         
         it "should include matching group skills" do
-          @char.stub(:group).with("Position") { "Pilot" }
-          @char.stub(:group).with("Faction") { "Other" }
+          allow(@char).to receive(:group).with("Position") { "Pilot" }
+          allow(@char).to receive(:group).with("Faction") { "Other" }
           skills = { "A" => 2, "B" => 3, "C" => 4 }
-          StartingSkills.get_skills_for_char(@char).should eq skills
+          expect(StartingSkills.get_skills_for_char(@char)).to eq skills
         end
 
         it "should include the higher skill if multiple matches" do
-          @char.stub(:group).with("Position") { "Pilot" }
-          @char.stub(:group).with("Faction") { "Navy" }
+          allow(@char).to receive(:group).with("Position") { "Pilot" }
+          allow(@char).to receive(:group).with("Faction") { "Navy" }
           skills = { "A" => 2, "B" => 3, "C" => 4 }
-          StartingSkills.get_skills_for_char(@char).should eq skills
+          expect(StartingSkills.get_skills_for_char(@char)).to eq skills
         end
         
         it "should include default attributes" do
-          @char.stub(:group).with("Position") { "Other" }
-          @char.stub(:group).with("Faction") { "Other" }
-          Global.stub(:read_config).with("fs3skills", "attributes") { [ { 'name' => 'Brawn' }, { 'name' => 'Presence' } ] }
+          allow(@char).to receive(:group).with("Position") { "Other" }
+          allow(@char).to receive(:group).with("Faction") { "Other" }
+          allow(Global).to receive(:read_config).with("fs3skills", "attributes") { [ { 'name' => 'Brawn' }, { 'name' => 'Presence' } ] }
           skills = { "A" => 2, "B" => 3, "Brawn" => 1, "Presence" => 1 }
-          StartingSkills.get_skills_for_char(@char).should eq skills        
+          expect(StartingSkills.get_skills_for_char(@char)).to eq skills        
         end
         
         it "should include default action skills when unskilled allowed" do
-          @char.stub(:group).with("Position") { "Other" }
-          @char.stub(:group).with("Faction") { "Other" }
-          Global.stub(:read_config).with("fs3skills", "action_skills") { [ { 'name' => 'Melee' } ] }
-          Global.stub(:read_config).with("fs3skills", "allow_unskilled_action_skills") { true }
+          allow(@char).to receive(:group).with("Position") { "Other" }
+          allow(@char).to receive(:group).with("Faction") { "Other" }
+          allow(Global).to receive(:read_config).with("fs3skills", "action_skills") { [ { 'name' => 'Melee' } ] }
+          allow(Global).to receive(:read_config).with("fs3skills", "allow_unskilled_action_skills") { true }
           skills = { "A" => 2, "B" => 3, "Melee" => 0 }
-          StartingSkills.get_skills_for_char(@char).should eq skills        
+          expect(StartingSkills.get_skills_for_char(@char)).to eq skills        
         end
 
         it "should include default action skills when unskilled not allowed" do
-          @char.stub(:group).with("Position") { "Other" }
-          @char.stub(:group).with("Faction") { "Other" }
-          Global.stub(:read_config).with("fs3skills", "action_skills") { [ { 'name' => 'Melee' } ] }
-          Global.stub(:read_config).with("fs3skills", "allow_unskilled_action_skills") { false }
+          allow(@char).to receive(:group).with("Position") { "Other" }
+          allow(@char).to receive(:group).with("Faction") { "Other" }
+          allow(Global).to receive(:read_config).with("fs3skills", "action_skills") { [ { 'name' => 'Melee' } ] }
+          allow(Global).to receive(:read_config).with("fs3skills", "allow_unskilled_action_skills") { false }
           skills = { "A" => 2, "B" => 3, "Melee" => 1 }
-          StartingSkills.get_skills_for_char(@char).should eq skills        
+          expect(StartingSkills.get_skills_for_char(@char)).to eq skills        
         end
       end
       
@@ -79,29 +79,29 @@ module AresMUSH
             "Position" => { "Pilot" => { "skills" => { "C" => 4 }, "specialties" => { "A" => [ "X", "U" ] } } },
             "Faction" => { "Navy" => { "skills" => { "C" => 2 }, "specialties" => { "B" => [ "W" ] } } }
           }
-          Global.stub(:read_config).with("fs3skills", "starting_skills") { starting_skills }
+          allow(Global).to receive(:read_config).with("fs3skills", "starting_skills") { starting_skills }
           @char = double
         end
         
         it "should include Everyone skills" do
-          @char.stub(:group).with("Position") { "Other" }
-          @char.stub(:group).with("Faction") { "Other" }
+          allow(@char).to receive(:group).with("Position") { "Other" }
+          allow(@char).to receive(:group).with("Faction") { "Other" }
           specs = { "A" => [ "X", "Y" ], "B" => [ "Z" ] }
-          StartingSkills.get_specialties_for_char(@char).should eq specs
+          expect(StartingSkills.get_specialties_for_char(@char)).to eq specs
         end
         
         it "should include matching group skills" do
-          @char.stub(:group).with("Position") { "Pilot" }
-          @char.stub(:group).with("Faction") { "Other" }
+          allow(@char).to receive(:group).with("Position") { "Pilot" }
+          allow(@char).to receive(:group).with("Faction") { "Other" }
           specs = { "A" => [ "X", "Y", "U" ], "B" => [ "Z" ] }
-          StartingSkills.get_specialties_for_char(@char).should eq specs
+          expect(StartingSkills.get_specialties_for_char(@char)).to eq specs
         end
 
         it "should include the higher skill if multiple matches" do
-          @char.stub(:group).with("Position") { "Pilot" }
-          @char.stub(:group).with("Faction") { "Navy" }
+          allow(@char).to receive(:group).with("Position") { "Pilot" }
+          allow(@char).to receive(:group).with("Faction") { "Navy" }
           specs = { "A" => [ "X", "Y", "U" ], "B" => [ "Z", "W" ] }
-          StartingSkills.get_specialties_for_char(@char).should eq specs
+          expect(StartingSkills.get_specialties_for_char(@char)).to eq specs
         end
         
       end

--- a/plugins/fs3skills/specs/xp_specs.rb
+++ b/plugins/fs3skills/specs/xp_specs.rb
@@ -3,8 +3,8 @@ module AresMUSH
     describe FS3Skills do
 
       before do
-        Global.stub(:read_config).with("fs3skills", "max_xp_hoard") { 3 }
-        SpecHelpers.stub_translate_for_testing
+        allow(Global).to receive(:read_config).with("fs3skills", "max_xp_hoard") { 3 }
+        stub_translate_for_testing
       end
       
       describe :award_xp do
@@ -13,12 +13,12 @@ module AresMUSH
         end
         
         it "should add xp" do
-          @char.should_receive(:update).with(fs3_xp: 2)
+          expect(@char).to receive(:update).with(fs3_xp: 2)
           @char.award_xp(1)
         end
 
         it "should not go over the cap" do
-          @char.should_receive(:update).with(fs3_xp: 3)
+          expect(@char).to receive(:update).with(fs3_xp: 3)
           @char.award_xp(5)
         end
       end
@@ -26,41 +26,41 @@ module AresMUSH
       describe :check_can_learn do
         before do
           @char = double
-          Global.stub(:read_config).with("fs3skills", "max_points_on_attrs") { 14 }
-          Global.stub(:read_config).with("fs3skills", "max_points_on_action") { 10 }
-          Global.stub(:read_config).with("fs3skills", "dots_beyond_chargen_max") { 1 }
-          FS3Skills.stub(:get_ability_type).with("Firearms") { :action }
+          allow(Global).to receive(:read_config).with("fs3skills", "max_points_on_attrs") { 14 }
+          allow(Global).to receive(:read_config).with("fs3skills", "max_points_on_action") { 10 }
+          allow(Global).to receive(:read_config).with("fs3skills", "dots_beyond_chargen_max") { 1 }
+          allow(FS3Skills).to receive(:get_ability_type).with("Firearms") { :action }
         end
         
         it "should return false if next rating not in cost chart" do
-          FS3Skills.should_receive(:xp_needed).with("Firearms", 4) { nil }
-          FS3Skills.check_can_learn(@char, "Firearms", 4).should eq "fs3skills.cant_raise_further_with_xp"
+          expect(FS3Skills).to receive(:xp_needed).with("Firearms", 4) { nil }
+          expect(FS3Skills.check_can_learn(@char, "Firearms", 4)).to eq "fs3skills.cant_raise_further_with_xp"
         end
         
         it "should return false if char is at max in action already" do
-          FS3Skills.should_receive(:xp_needed).with("Firearms", 4) { 4 }
-          FS3Skills::AbilityPointCounter.stub(:points_on_action).with(@char) { 11 }
-          FS3Skills.check_can_learn(@char, "Firearms", 4).should eq "fs3skills.max_ability_points_reached"
+          expect(FS3Skills).to receive(:xp_needed).with("Firearms", 4) { 4 }
+          allow(FS3Skills::AbilityPointCounter).to receive(:points_on_action).with(@char) { 11 }
+          expect(FS3Skills.check_can_learn(@char, "Firearms", 4)).to eq "fs3skills.max_ability_points_reached"
         end
         
         it "should return ok if char would be at max after spending on action" do
-          FS3Skills.should_receive(:xp_needed).with("Firearms", 4) { 4 }
-          FS3Skills::AbilityPointCounter.stub(:points_on_action).with(@char) { 10 }
-          FS3Skills.check_can_learn(@char, "Firearms", 4).should eq nil
+          expect(FS3Skills).to receive(:xp_needed).with("Firearms", 4) { 4 }
+          allow(FS3Skills::AbilityPointCounter).to receive(:points_on_action).with(@char) { 10 }
+          expect(FS3Skills.check_can_learn(@char, "Firearms", 4)).to eq nil
         end
         
         it "should return false if char is at max in attrs already" do
-          FS3Skills.should_receive(:xp_needed).with("Firearms", 4) { 4 }
-          FS3Skills.stub(:get_ability_type).with("Firearms") { :attribute }
-          FS3Skills::AbilityPointCounter.stub(:points_on_attrs).with(@char) { 16 }
-          FS3Skills.check_can_learn(@char, "Firearms", 4).should eq "fs3skills.max_ability_points_reached"
+          expect(FS3Skills).to receive(:xp_needed).with("Firearms", 4) { 4 }
+          allow(FS3Skills).to receive(:get_ability_type).with("Firearms") { :attribute }
+          allow(FS3Skills::AbilityPointCounter).to receive(:points_on_attrs).with(@char) { 16 }
+          expect(FS3Skills.check_can_learn(@char, "Firearms", 4)).to eq "fs3skills.max_ability_points_reached"
         end
 
         it "should return ok if char would be at max after spending on attrs" do
-          FS3Skills.should_receive(:xp_needed).with("Firearms", 4) { 4 }
-          FS3Skills.stub(:get_ability_type).with("Firearms") { :attribute }
-          FS3Skills::AbilityPointCounter.stub(:points_on_attrs).with(@char) { 14 }
-          FS3Skills.check_can_learn(@char, "Firearms", 4).should eq nil
+          expect(FS3Skills).to receive(:xp_needed).with("Firearms", 4) { 4 }
+          allow(FS3Skills).to receive(:get_ability_type).with("Firearms") { :attribute }
+          allow(FS3Skills::AbilityPointCounter).to receive(:points_on_attrs).with(@char) { 14 }
+          expect(FS3Skills.check_can_learn(@char, "Firearms", 4)).to eq nil
         end
       end
       
@@ -70,7 +70,7 @@ module AresMUSH
         end
         
         it "should return xp" do
-          @char.xp.should eq 2
+          expect(@char.xp).to eq 2
         end
       end
     end

--- a/plugins/ictime/specs/ictime_specs.rb
+++ b/plugins/ictime/specs/ictime_specs.rb
@@ -4,75 +4,75 @@ module AresMUSH
   module ICTime
     describe ICTime do
       before do
-        Global.stub(:read_config).with("ictime", "time_ratio") { 1 } 
+        allow(Global).to receive(:read_config).with("ictime", "time_ratio") { 1 } 
       end
       
       it "should subtract a year offset" do
-        Global.stub(:read_config).with("ictime", "day_offset") { 0 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { -300 } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { 0 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { -300 } 
         
-        DateTime.stub(:now) { DateTime.new(2014, 01, 27) }
-        ICTime.ictime.should eq DateTime.new(1714, 01, 27)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 01, 27) }
+        expect(ICTime.ictime).to eq DateTime.new(1714, 01, 27)
       end      
 
       it "should add a year offset" do
-        Global.stub(:read_config).with("ictime", "day_offset") { 0 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { 300 } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { 0 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { 300 } 
 
-        DateTime.stub(:now) { DateTime.new(2014, 01, 27) }
-        ICTime.ictime.should eq DateTime.new(2314, 01, 27)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 01, 27) }
+        expect(ICTime.ictime).to eq DateTime.new(2314, 01, 27)
       end      
       
       it "should handle a day offset" do
-        Global.stub(:read_config).with("ictime", "day_offset") { 2 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { 100 } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { 2 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { 100 } 
 
-        DateTime.stub(:now) { DateTime.new(2014, 01, 27) }
-        ICTime.ictime.should eq DateTime.new(2114, 01, 29)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 01, 27) }
+        expect(ICTime.ictime).to eq DateTime.new(2114, 01, 29)
       end
 
       it "should handle a day offset across month boundaries" do
-        Global.stub(:read_config).with("ictime", "day_offset") { -2 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { 100 } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { -2 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { 100 } 
 
-        DateTime.stub(:now) { DateTime.new(2014, 01, 01) }
-        ICTime.ictime.should eq DateTime.new(2113, 12, 30)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 01, 01) }
+        expect(ICTime.ictime).to eq DateTime.new(2113, 12, 30)
       end
       
       it "should handle a day offset that causes an invalid date" do
-        Global.stub(:read_config).with("ictime", "day_offset") { 2 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { 100 } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { 2 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { 100 } 
 
-        DateTime.stub(:now) { DateTime.new(2014, 02, 27) }
-        ICTime.ictime.should eq DateTime.new(2114, 03, 01)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 02, 27) }
+        expect(ICTime.ictime).to eq DateTime.new(2114, 03, 01)
       end
       
       it "should show time too" do
-        Global.stub(:read_config).with("ictime", "day_offset") { 2 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { 100 } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { 2 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { 100 } 
 
-        DateTime.stub(:now) { DateTime.new(2014, 01, 27, 5, 55, 23) }
-        ICTime.ictime.should eq DateTime.new(2114, 01, 29, 5, 55, 23)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 01, 27, 5, 55, 23) }
+        expect(ICTime.ictime).to eq DateTime.new(2114, 01, 29, 5, 55, 23)
       end
       
       it "should handle a slow time ratio" do
-        Global.stub(:read_config).with("ictime", "day_offset") { 0 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { 100 } 
-        Global.stub(:read_config).with("ictime", "time_ratio") { 0.5 } 
-        Global.stub(:read_config).with("ictime", "game_start_date") { "1/1/2014" } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { 0 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { 100 } 
+        allow(Global).to receive(:read_config).with("ictime", "time_ratio") { 0.5 } 
+        allow(Global).to receive(:read_config).with("ictime", "game_start_date") { "1/1/2014" } 
 
-        DateTime.stub(:now) { DateTime.new(2014, 01, 21, 0, 0, 0) }
-        ICTime.ictime.should eq DateTime.new(2114, 01, 11, 0, 0, 0)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 01, 21, 0, 0, 0) }
+        expect(ICTime.ictime).to eq DateTime.new(2114, 01, 11, 0, 0, 0)
       end
 
       it "should handle a fast time ratio" do
-        Global.stub(:read_config).with("ictime", "day_offset") { 0 } 
-        Global.stub(:read_config).with("ictime", "year_offset") { 100 } 
-        Global.stub(:read_config).with("ictime", "time_ratio") { 2 } 
-        Global.stub(:read_config).with("ictime", "game_start_date") { "1/1/2014" } 
+        allow(Global).to receive(:read_config).with("ictime", "day_offset") { 0 } 
+        allow(Global).to receive(:read_config).with("ictime", "year_offset") { 100 } 
+        allow(Global).to receive(:read_config).with("ictime", "time_ratio") { 2 } 
+        allow(Global).to receive(:read_config).with("ictime", "game_start_date") { "1/1/2014" } 
 
-        DateTime.stub(:now) { DateTime.new(2014, 01, 3) } # 2 days elapsed from 1/1 -> 1/3
-        ICTime.ictime.should eq DateTime.new(2114, 01, 5)
+        allow(DateTime).to receive(:now) { DateTime.new(2014, 01, 3) } # 2 days elapsed from 1/1 -> 1/3
+        expect(ICTime.ictime).to eq DateTime.new(2114, 01, 5)
       end
       
     end

--- a/plugins/login/specs/connect_specs.rb
+++ b/plugins/login/specs/connect_specs.rb
@@ -6,14 +6,14 @@ module AresMUSH
       include GlobalTestHelper
       
       before do
-        SpecHelpers.stub_translate_for_testing  
+        stub_translate_for_testing  
         stub_global_objects      
         @found_char = double
         @client = double
-        @client.stub(:ip_addr) { "" }
-        @found_char.stub(:login_failures) { 0 }
-        @found_char.stub(:is_statue?) { false }
-        @client.stub(:logged_in?) { false }
+        allow(@client).to receive(:ip_addr) { "" }
+        allow(@found_char).to receive(:login_failures) { 0 }
+        allow(@found_char).to receive(:is_statue?) { false }
+        allow(@client).to receive(:logged_in?) { false }
         
         @handler = ConnectCmd.new(@client, Command.new("connect Bob password"), nil)
       end
@@ -21,134 +21,134 @@ module AresMUSH
       describe :crack do
         it "should crack the arguments" do
           @handler.parse_args
-          @handler.charname.should eq "Bob"
-          @handler.password.should eq "password"
+          expect(@handler.charname).to eq "Bob"
+          expect(@handler.password).to eq "password"
         end
         
         it "should handle no args" do
           @handler = ConnectCmd.new(@client, Command.new("connect"), nil)
           @handler.parse_args
-          @handler.charname.should be_nil
-          @handler.password.should be_nil
+          expect(@handler.charname).to be_nil
+          expect(@handler.password).to be_nil
         end
         
         it "should handle a missing password" do
           @handler = ConnectCmd.new(@client, Command.new("connect Bob"), nil)
           @handler.parse_args
-          @handler.charname.should eq "Bob"
-          @handler.password.should eq ""
+          expect(@handler.charname).to eq "Bob"
+          expect(@handler.password).to eq ""
         end
 
         it "should accept a multi-word password" do
           @handler = ConnectCmd.new(@client, Command.new("connect Bob bob's password"), nil)
           @handler.parse_args
-          @handler.charname.should eq "Bob"
-          @handler.password.should eq "bob's password"
+          expect(@handler.charname).to eq "Bob"
+          expect(@handler.password).to eq "bob's password"
         end
       end  
      
       describe :check_not_already_logged_in do
         it "should reject command if already logged in" do
-          @client.stub(:logged_in?) { true }
-          @handler.check_not_already_logged_in.should eq "login.already_logged_in"
+          allow(@client).to receive(:logged_in?) { true }
+          expect(@handler.check_not_already_logged_in).to eq "login.already_logged_in"
         end
        
         it "should accept command if not already logged in" do
-          @client.stub(:logged_in?) { false }
-          @handler.check_not_already_logged_in.should eq nil
+          allow(@client).to receive(:logged_in?) { false }
+          expect(@handler.check_not_already_logged_in).to eq nil
         end
       end
      
       describe :handle do  
         before do
-          Login.stub(:terms_of_service) { nil }
-          @client.stub(:program) { {} }       
+          allow(Login).to receive(:terms_of_service) { nil }
+          allow(@client).to receive(:program) { {} }       
           
           @handler.parse_args
         end
              
         context "failure" do
           it "should fail if there isn't a matching char" do
-            Character.should_receive(:find_any_by_name).with("Bob") { [] }
-            Global.should_not_receive(:queue_event)
-            @client.should_receive(:emit_failure).with("db.object_not_found")
+            expect(Character).to receive(:find_any_by_name).with("Bob") { [] }
+            expect(Global).to_not receive(:queue_event)
+            expect(@client).to receive(:emit_failure).with("db.object_not_found")
             @handler.handle
           end
                          
           it "should fail if the passwords don't match" do
-            @found_char.should_receive(:compare_password).with("password") { false }
-            Character.should_receive(:find_any_by_name).with("Bob") { [@found_char] }
-            @client.should_receive(:emit_failure).with("login.password_incorrect")
-            @found_char.should_receive(:update).with(login_failures: 1)
-            Global.should_not_receive(:queue_event)
+            expect(@found_char).to receive(:compare_password).with("password") { false }
+            expect(Character).to receive(:find_any_by_name).with("Bob") { [@found_char] }
+            expect(@client).to receive(:emit_failure).with("login.password_incorrect")
+            expect(@found_char).to receive(:update).with(login_failures: 1)
+            expect(Global).to_not receive(:queue_event)
             @handler.handle
           end
           
           it "should fail if char is a statue" do
-            Character.should_receive(:find_any_by_name).with("Bob") { [@found_char] }
-            @found_char.should_receive(:is_statue?) { true }
-            @client.should_receive(:emit_failure).with("dispatcher.you_are_statue")            
-            Global.should_not_receive(:queue_event)
+            expect(Character).to receive(:find_any_by_name).with("Bob") { [@found_char] }
+            expect(@found_char).to receive(:is_statue?) { true }
+            expect(@client).to receive(:emit_failure).with("dispatcher.you_are_statue")            
+            expect(Global).to_not receive(:queue_event)
             @handler.handle
           end
         end
      
         context "success" do
           before do
-            Login.stub(:find_client).with(@found_char) { nil }
-            @found_char.stub(:id) { 3 }
-            Character.should_receive(:find_any_by_name) { [ @found_char ] }
-            @found_char.stub(:compare_password).with("password") { true }  
-            @found_char.stub(:update) {}
-            dispatcher.stub(:queue_event)  
-            @client.stub(:char_id=)      
+            allow(Login).to receive(:find_client).with(@found_char) { nil }
+            allow(@found_char).to receive(:id) { 3 }
+            expect(Character).to receive(:find_any_by_name) { [ @found_char ] }
+            allow(@found_char).to receive(:compare_password).with("password") { true }  
+            allow(@found_char).to receive(:update) {}
+            allow(dispatcher).to receive(:queue_event)  
+            allow(@client).to receive(:char_id=)      
           end
           
           it "should disconnect an existing client" do
             other_client = double
-            Login.stub(:find_client).with(@found_char) { other_client }
-            other_client.should_receive(:emit_ooc).with('login.disconnected_by_reconnect')
-            other_client.should_receive(:disconnect)
-            dispatcher.stub(:queue_timer)
+            allow(Login).to receive(:find_client).with(@found_char) { other_client }
+            expect(other_client).to receive(:emit_ooc).with('login.disconnected_by_reconnect')
+            expect(other_client).to receive(:disconnect)
+            allow(dispatcher).to receive(:queue_timer)
             @handler.handle            
           end
           
           it "should compare passwords" do
-            @found_char.should_receive(:compare_password).with("password")
+            expect(@found_char).to receive(:compare_password).with("password")
             @handler.handle
           end        
        
           it "should set the char on the client" do
-            @client.should_receive(:char_id=).with(3)
+            expect(@client).to receive(:char_id=).with(3)
             @handler.handle
           end
           
           it "should reset login failures" do
-            @found_char.should_receive(:update).with(login_failures: 0)
+            expect(@found_char).to receive(:update).with(login_failures: 0)
             @handler.handle
           end
 
           it "should announce the char connected event" do
-            dispatcher.should_receive(:queue_event) do |event|
-              event.class.should eq CharConnectedEvent
-              event.client.should eq @client
+            expect(dispatcher).to receive(:queue_event) do |event|
+              expect(event.class).to eq CharConnectedEvent
+              expect(event.client).to eq @client
             end
             @handler.handle
           end
           
         
           it "should prompt with the terms of service if defined and not acknowledged" do
-            Login.stub(:terms_of_service) { "tos text" }
-            @found_char.stub(:terms_of_service_acknowledged) { nil }
-            @client.should_receive(:emit).with("%lh\ntos text%rlogin.tos_agree\n%lf")
-            @client.should_not_receive(:char_id=)
+            allow(Login).to receive(:terms_of_service) { "tos text" }
+            allow(@found_char).to receive(:terms_of_service_acknowledged) { nil }
+            expect(@client).to receive(:emit).with("%lh\ntos text%rlogin.tos_agree\n%lf")
+            expect(@client).to_not receive(:char_id=)
             @handler.handle
           end
           
           it "should not prompt for TOS if already acknowledged" do
-            Login.stub(:terms_of_service) { "tos text" }
-            @found_char.stub(:terms_of_service_acknowledged) { DateTime.now }
-            @client.should_receive(:char_id=).with(3)
+            allow(Login).to receive(:terms_of_service) { "tos text" }
+            allow(@found_char).to receive(:terms_of_service_acknowledged) { DateTime.now }
+            expect(@client).to receive(:char_id=).with(3)
             @handler.handle
           end
           

--- a/plugins/login/specs/create_specs.rb
+++ b/plugins/login/specs/create_specs.rb
@@ -8,57 +8,57 @@ module AresMUSH
       before do
         @client = double
         @handler = CreateCmd.new(@client, "create Bob bobpassword", nil)
-        SpecHelpers.stub_translate_for_testing    
+        stub_translate_for_testing    
         stub_global_objects    
       end
       
       describe :check_not_already_logged_in do
         it "should reject command if already logged in" do
-          @client.stub(:logged_in?) { true }
-          @handler.check_not_already_logged_in .should eq "login.already_logged_in"
+          allow(@client).to receive(:logged_in?) { true }
+          expect(@handler.check_not_already_logged_in ).to eq "login.already_logged_in"
         end
 
         it "should allow command if not logged in" do
-          @client.stub(:logged_in?) { false }
-          @handler.check_not_already_logged_in .should be_nil
+          allow(@client).to receive(:logged_in?) { false }
+          expect(@handler.check_not_already_logged_in ).to be_nil
         end
       end
       
       describe :check_name do
         it "should fail if the name is missing" do
-          @handler.stub(:charname) { nil }
-          @handler.check_name.should eq "dispatcher.invalid_syntax"
+          allow(@handler).to receive(:charname) { nil }
+          expect(@handler.check_name).to eq "dispatcher.invalid_syntax"
         end
 
         it "should fail if the name is invalid" do
-          @handler.stub(:charname) { "Bob" }
-          Character.should_receive(:check_name).with("Bob") { "invalid name"}
-          @handler.check_name.should eq "invalid name"          
+          allow(@handler).to receive(:charname) { "Bob" }
+          expect(Character).to receive(:check_name).with("Bob") { "invalid name"}
+          expect(@handler.check_name).to eq "invalid name"          
         end
           
         it "should allow the comand if the name is ok" do
-          @handler.stub(:charname) { "Bob" }
-          Character.should_receive(:check_name) { nil }
-          @handler.check_name.should be_nil
+          allow(@handler).to receive(:charname) { "Bob" }
+          expect(Character).to receive(:check_name) { nil }
+          expect(@handler.check_name).to be_nil
         end
       end
         
       describe :check_password do
         it "should fail if the password is missing" do
-          @handler.stub(:password) { nil }
-          @handler.check_password.should eq "dispatcher.invalid_syntax"
+          allow(@handler).to receive(:password) { nil }
+          expect(@handler.check_password).to eq "dispatcher.invalid_syntax"
         end
 
         it "should fail if the password is invalid" do
-          @handler.stub(:password) { "passwd" }
-          Character.should_receive(:check_password).with("passwd") { "invalid password"}
-          @handler.check_password.should eq "invalid password"          
+          allow(@handler).to receive(:password) { "passwd" }
+          expect(Character).to receive(:check_password).with("passwd") { "invalid password"}
+          expect(@handler.check_password).to eq "invalid password"          
         end
           
         it "should allow the comand if the password is ok" do
-          @handler.stub(:password) { "passwd" }
-          Character.should_receive(:check_password) { nil }
-          @handler.check_password.should be_nil
+          allow(@handler).to receive(:password) { "passwd" }
+          expect(Character).to receive(:check_password) { nil }
+          expect(@handler.check_password).to be_nil
         end
       end
       
@@ -68,66 +68,66 @@ module AresMUSH
           @handler.charname = "charname"
           @handler.password = "password"
           
-          dispatcher.stub(:queue_event)
+          allow(dispatcher).to receive(:queue_event)
 
-          Login.stub(:terms_of_service) { nil }
+          allow(Login).to receive(:terms_of_service) { nil }
           
           @char = double.as_null_object
-          @char.stub(:id) { 33 }
-          Character.stub(:new) { @char }
+          allow(@char).to receive(:id) { 33 }
+          allow(Character).to receive(:new) { @char }
 
-          @client.stub(:emit_success)
-          @client.stub(:char_id=) 
-          @client.stub(:program) { {} }       
+          allow(@client).to receive(:emit_success)
+          allow(@client).to receive(:char_id=) 
+          allow(@client).to receive(:program) { {} }       
         
           game = double
-          Game.stub(:master) { game }
-          game.stub(:welcome_room) { double }
-          SpecHelpers.stub_translate_for_testing        
+          allow(Game).to receive(:master) { game }
+          allow(game).to receive(:welcome_room) { double }
+          stub_translate_for_testing        
         end
         
         it "should set the character's name" do          
-          @char.should_receive(:name=).with("charname")
+          expect(@char).to receive(:name=).with("charname")
           @handler.handle
         end
 
         it "should set the character's password" do          
-          @char.should_receive(:change_password).with("password")
+          expect(@char).to receive(:change_password).with("password")
           @handler.handle
         end
 
         it "should save the character" do          
-          @char.should_receive(:save)
+          expect(@char).to receive(:save)
           @handler.handle
         end
 
         it "should tell the char they're created" do
-          @client.should_receive(:emit_success).with("login.created_and_logged_in")
+          expect(@client).to receive(:emit_success).with("login.created_and_logged_in")
           @handler.handle
         end
 
         it "should set the char on the @client" do
-          @client.should_receive(:char_id=).with(33)
+          expect(@client).to receive(:char_id=).with(33)
           @handler.handle
         end
 
         it "should dispatch the created and connected event" do
-          dispatcher.should_receive(:queue_event) do |event|
-            event.class.should eq CharCreatedEvent
-            event.client.should eq @client
+          expect(dispatcher).to receive(:queue_event) do |event|
+            expect(event.class).to eq CharCreatedEvent
+            expect(event.client).to eq @client
           end
          
-          dispatcher.should_receive(:queue_event) do |event|
-            event.class.should eq CharConnectedEvent
-            event.client.should eq @client
+          expect(dispatcher).to receive(:queue_event) do |event|
+            expect(event.class).to eq CharConnectedEvent
+            expect(event.client).to eq @client
           end
           @handler.handle
         end
         
         it "should prompt with the terms of service if defined" do
-          Login.stub(:terms_of_service) { "tos text" }
-          @client.should_receive(:emit).with("%lh\ntos text%rlogin.tos_agree\n%lf")
-          @client.should_not_receive(:char=)
+          allow(Login).to receive(:terms_of_service) { "tos text" }
+          expect(@client).to receive(:emit).with("%lh\ntos text%rlogin.tos_agree\n%lf")
+          expect(@client).to_not receive(:char=)
           @handler.handle
         end
       end

--- a/plugins/login/specs/login_events_specs.rb
+++ b/plugins/login/specs/login_events_specs.rb
@@ -6,76 +6,76 @@ module AresMUSH
       include GlobalTestHelper
       
       before do
-        AresMUSH::Locale.stub(:translate).with("login.announce_char_connected", { :name => "Bob" }) { "announce_char_connected" }
-        AresMUSH::Locale.stub(:translate).with("login.announce_char_disconnected", { :name => "Bob" }) { "announce_char_disconnected" }
-        AresMUSH::Locale.stub(:translate).with("login.announce_char_connected_here", { :name => "Bob" }) { "announce_char_connected_here" }
-        AresMUSH::Locale.stub(:translate).with("login.announce_char_disconnected_here", { :name => "Bob" }) { "announce_char_disconnected_here" }
-        AresMUSH::Locale.stub(:translate).with("login.announce_char_created", { :name => "Bob" }) { "announce_char_created" }
+        allow(AresMUSH::Locale).to receive(:translate).with("login.announce_char_connected", { :name => "Bob" }) { "announce_char_connected" }
+        allow(AresMUSH::Locale).to receive(:translate).with("login.announce_char_disconnected", { :name => "Bob" }) { "announce_char_disconnected" }
+        allow(AresMUSH::Locale).to receive(:translate).with("login.announce_char_connected_here", { :name => "Bob" }) { "announce_char_connected_here" }
+        allow(AresMUSH::Locale).to receive(:translate).with("login.announce_char_disconnected_here", { :name => "Bob" }) { "announce_char_disconnected_here" }
+        allow(AresMUSH::Locale).to receive(:translate).with("login.announce_char_created", { :name => "Bob" }) { "announce_char_created" }
         stub_global_objects
         
         @room_client = double(Client)
         @room_char = double
         @room = double
 
-        @room_client.stub(:room) { @room }
-        @room_char.stub(:room) { @room }
-        @room_char.stub(:name) { "Bob" }
-        client_monitor.stub(:logged_in) { { @room_client => @room_char } }
-        notifier.stub(:notify_ooc)
-        Login.stub(:wants_announce) { false }
-        Login.stub(:is_online?) { true }
+        allow(@room_client).to receive(:room) { @room }
+        allow(@room_char).to receive(:room) { @room }
+        allow(@room_char).to receive(:name) { "Bob" }
+        allow(client_monitor).to receive(:logged_in) { { @room_client => @room_char } }
+        allow(notifier).to receive(:notify_ooc)
+        allow(Login).to receive(:wants_announce) { false }
+        allow(Login).to receive(:is_online?) { true }
         
         @event_char = double
         @event_client = double
-        @event_char.stub(:name) { "Bob" }
-        @event_char.stub(:room) { nil }    
+        allow(@event_char).to receive(:name) { "Bob" }
+        allow(@event_char).to receive(:room) { nil }    
 
         @event_char_id = 111
-        Character.stub(:[]).with(@event_char_id) { @event_char }
+        allow(Character).to receive(:[]).with(@event_char_id) { @event_char }
       end
       
       describe :on_char_connected_event do
         before do
-          @event_char.stub(:last_ip) { "127" }
-          @event_char.stub(:last_hostname) { "localhost" }
-          Login.stub(:update_site_info) {}
+          allow(@event_char).to receive(:last_ip) { "127" }
+          allow(@event_char).to receive(:last_hostname) { "localhost" }
+          allow(Login).to receive(:update_site_info) {}
           @login_events = CharConnectedEventHandler.new
-          @room_client.stub(:emit_success)
-          @event_char.stub(:onconnect_commands) { [] }
-          dispatcher.stub(:queue_timer)
+          allow(@room_client).to receive(:emit_success)
+          allow(@event_char).to receive(:onconnect_commands) { [] }
+          allow(dispatcher).to receive(:queue_timer)
         end
         
         it "should update the site info" do
-          Login.should_receive(:update_site_info).with(@event_client, @event_char) {}
+          expect(Login).to receive(:update_site_info).with(@event_client, @event_char) {}
           @login_events.on_event CharConnectedEvent.new(@event_client, @event_char_id)
         end
         
         it "should announce the char if the client wants it" do
-          Login.stub(:wants_announce) { true }
-          @room_client.should_receive(:emit_ooc).with("announce_char_connected")
+          allow(Login).to receive(:wants_announce) { true }
+          expect(@room_client).to receive(:emit_ooc).with("announce_char_connected")
           @login_events.on_event CharConnectedEvent.new(@event_client, @event_char_id)
         end
 
         it "should not announce the char if the client doesn't want it" do
-          Login.stub(:wants_announce) { false }
-          @room_client.should_not_receive(:emit_ooc)
+          allow(Login).to receive(:wants_announce) { false }
+          expect(@room_client).to_not receive(:emit_ooc)
           @login_events.on_event CharConnectedEvent.new(@event_client, @event_char_id)
         end
         
         it "should announce the char in the room" do
-          @event_char.stub(:room) { @room }
-          @room_client.should_receive(:emit_success).with("announce_char_connected_here")
+          allow(@event_char).to receive(:room) { @room }
+          expect(@room_client).to receive(:emit_success).with("announce_char_connected_here")
           @login_events.on_event CharConnectedEvent.new(@event_client, @event_char_id)
         end
         
         it "should check for suspect site on the first login" do
-          @event_char.stub(:last_ip) { nil }
-          Login.should_receive(:check_for_suspect).with(@event_char) {}
+          allow(@event_char).to receive(:last_ip) { nil }
+          expect(Login).to receive(:check_for_suspect).with(@event_char) {}
           @login_events.on_event CharCreatedEvent.new(@event_client, @event_char_id)
         end
 
         it "should not check for suspect site on subsequent login" do
-          Login.should_not_receive(:check_for_suspect).with(@event_char) {}
+          expect(Login).to_not receive(:check_for_suspect).with(@event_char) {}
           @login_events.on_event CharCreatedEvent.new(@event_client, @event_char_id)
         end
         
@@ -83,14 +83,14 @@ module AresMUSH
       
       describe :on_char_created_event do
         before do
-          Login.stub(:update_site_info) {}
-          Login.stub(:check_for_suspect) {}
-          client_monitor.stub(:emit_all_ooc)          
+          allow(Login).to receive(:update_site_info) {}
+          allow(Login).to receive(:check_for_suspect) {}
+          allow(client_monitor).to receive(:emit_all_ooc)          
           @login_events = CharCreatedEventHandler.new
         end
         
         it "should announce the char" do
-          notifier.should_receive(:notify_ooc).with(:char_created, "announce_char_created")
+          expect(notifier).to receive(:notify_ooc).with(:char_created, "announce_char_created")
           @login_events.on_event CharCreatedEvent.new(@event_client, @event_char_id)
         end
       end
@@ -101,20 +101,20 @@ module AresMUSH
         end
         
         it "should announce the char if the client wants it" do
-          Login.stub(:wants_announce) { true }
-          @room_client.should_receive(:emit_ooc).with("announce_char_disconnected")
+          allow(Login).to receive(:wants_announce) { true }
+          expect(@room_client).to receive(:emit_ooc).with("announce_char_disconnected")
           @login_events.on_event CharDisconnectedEvent.new(@event_client, @event_char_id)
         end
         
         it "should not announce the char if the client doesn't want it" do
-          Login.stub(:wants_announce) { false }
-          @room_client.should_not_receive(:emit_ooc)
+          allow(Login).to receive(:wants_announce) { false }
+          expect(@room_client).to_not receive(:emit_ooc)
           @login_events.on_event CharDisconnectedEvent.new(@event_client, @event_char_id)
         end
 
         it "should announce the char in the room" do
-          @event_char.stub(:room) { @room }
-          @room_client.should_receive(:emit_success).with("announce_char_disconnected_here")
+          allow(@event_char).to receive(:room) { @room }
+          expect(@room_client).to receive(:emit_success).with("announce_char_disconnected_here")
           @login_events.on_event CharDisconnectedEvent.new(@event_client, @event_char_id)
         end
       end

--- a/plugins/login/specs/model_specs.rb
+++ b/plugins/login/specs/model_specs.rb
@@ -2,80 +2,80 @@ module AresMUSH
 
   describe Character do
     before do
-      SpecHelpers.stub_translate_for_testing
+      stub_translate_for_testing
     end
     
     describe :hash_password do
       it "should use bcrypt to hash the password" do
         password = double(BCrypt::Password)
-        BCrypt::Password.should_receive(:create).with("test") { password }
-        Character.hash_password("test").should eq password
+        expect(BCrypt::Password).to receive(:create).with("test") { password }
+        expect(Character.hash_password("test")).to eq password
       end
     end
     
     describe :compare_password do
       it "should return true if passwords match" do
         char = Character.new
-        char.stub(:save) {}
+        allow(char).to receive(:save) {}
         char.change_password("existing_pw")
-        char.compare_password("existing_pw").should be true
+        expect(char.compare_password("existing_pw")).to be true
       end
       
       it "should return false if passwords don't match" do
         char = Character.new
-        char.stub(:save) {}
+        allow(char).to receive(:save) {}
         char.change_password("existing_pw")
-        char.compare_password("other_password").should be false
+        expect(char.compare_password("other_password")).to be false
       end
     end
     
     describe :check_name do
       before do
-        Global.stub(:read_config).with("names", "restricted") { ["barney"] }
+        allow(Global).to receive(:read_config).with("names", "restricted") { ["barney"] }
       end
       
       it "should fail if name is too short" do
-        Character.check_name("A").should eq "validation.name_too_short"
+        expect(Character.check_name("A")).to eq "validation.name_too_short"
       end
       
       it "should fail if name contains an invalid char" do
-        Character.check_name("A_BC").should eq "validation.name_contains_invalid_chars"
-        Character.check_name("A BC").should eq "validation.name_contains_invalid_chars"
-        Character.check_name("A.BC").should eq "validation.name_contains_invalid_chars"
-        Character.check_name("B@ABC").should eq "validation.name_contains_invalid_chars"
+        expect(Character.check_name("A_BC")).to eq "validation.name_contains_invalid_chars"
+        expect(Character.check_name("A BC")).to eq "validation.name_contains_invalid_chars"
+        expect(Character.check_name("A.BC")).to eq "validation.name_contains_invalid_chars"
+        expect(Character.check_name("B@ABC")).to eq "validation.name_contains_invalid_chars"
       end
       
       it "should fail if the char already exists" do
-        Character.stub(:found?).with("Charname") { true }
-        Character.check_name("Charname").should eq "validation.char_name_taken"
+        allow(Character).to receive(:found?).with("Charname") { true }
+        expect(Character.check_name("Charname")).to eq "validation.char_name_taken"
       end
       
       it "should return true if everything's ok" do
-        Character.stub(:found?).with("Charname") { false }
-        Character.stub(:found?).with("O'Malley") { false }
-        Character.stub(:found?).with("This-Char") { false }
-        Character.check_name("Charname").should be_nil
-        Character.check_name("O'Malley").should be_nil
-        Character.check_name("This-Char").should be_nil
+        allow(Character).to receive(:found?).with("Charname") { false }
+        allow(Character).to receive(:found?).with("O'Malley") { false }
+        allow(Character).to receive(:found?).with("This-Char") { false }
+        expect(Character.check_name("Charname")).to be_nil
+        expect(Character.check_name("O'Malley")).to be_nil
+        expect(Character.check_name("This-Char")).to be_nil
       end
       
       it "should disallow a restricted name" do
-        Character.stub(:found?).with("Barney") { false }
-        Character.check_name("Barney").should eq "validation.name_is_restricted"
+        allow(Character).to receive(:found?).with("Barney") { false }
+        expect(Character.check_name("Barney")).to eq "validation.name_is_restricted"
       end
     end
     
     describe :check_password do
       it "should fail if password is too short" do
-        Character.check_password("bar").should eq "validation.password_too_short"
+        expect(Character.check_password("bar")).to eq "validation.password_too_short"
       end
       
       it "should fail if the password has an equal sign" do
-        Character.check_password("bar=foo").should eq "validation.password_cant_have_equals"
+        expect(Character.check_password("bar=foo")).to eq "validation.password_cant_have_equals"
       end
 
       it "should return true if everything's ok" do
-        Character.check_password("password").should be_nil
+        expect(Character.check_password("password")).to be_nil
       end
     end  
   end

--- a/plugins/login/specs/shared_specs.rb
+++ b/plugins/login/specs/shared_specs.rb
@@ -5,21 +5,21 @@ module AresMUSH
         before do
           @actor = double
           @other_char = double
-          Global.stub(:read_config).with("login", "manage_login") { ['admin'] }
+          allow(Global).to receive(:read_config).with("login", "manage_login") { ['admin'] }
         end
           
         it "should allow you to see your own email" do
-          Login.can_access_email?(@actor, @actor).should be true
+          expect(Login.can_access_email?(@actor, @actor)).to be true
         end
         
         it "should allow someone with the required role to see email" do
-          @actor.stub(:has_permission?).with("manage_login") { true }
-          Login.can_access_email?(@actor, @other_char).should be true
+          allow(@actor).to receive(:has_permission?).with("manage_login") { true }
+          expect(Login.can_access_email?(@actor, @other_char)).to be true
         end
         
         it "should not allow you to access someone else's email" do
-          @actor.stub(:has_permission?).with("manage_login") { false }
-          Login.can_access_email?(@actor, @other_char).should be false
+          allow(@actor).to receive(:has_permission?).with("manage_login") { false }
+          expect(Login.can_access_email?(@actor, @other_char)).to be false
         end
       end
       
@@ -29,13 +29,13 @@ module AresMUSH
         end
           
         it "should allow someone with the required role to reset a password" do
-          @actor.stub(:has_permission?).with("manage_login") { true }
-          Login.can_manage_login?(@actor).should be true
+          allow(@actor).to receive(:has_permission?).with("manage_login") { true }
+          expect(Login.can_manage_login?(@actor)).to be true
         end
         
         it "should not allow you to reset a password" do
-          @actor.stub(:has_permission?).with("manage_login") { false }
-          Login.can_manage_login?(@actor).should be false
+          allow(@actor).to receive(:has_permission?).with("manage_login") { false }
+          expect(Login.can_manage_login?(@actor)).to be false
         end
       end
       
@@ -46,25 +46,25 @@ module AresMUSH
         end
         
         it "should want announce if you're listening for everybody" do
-          @listener.stub(:login_watch) { "all" }
-          Login.wants_announce(@listener, @connector).should eq true
+          allow(@listener).to receive(:login_watch) { "all" }
+          expect(Login.wants_announce(@listener, @connector)).to eq true
         end 
         
         it "should not want announce if you've disabled it" do
-          @listener.stub(:login_watch) { "none" }
-          Login.wants_announce(@listener, @connector).should eq false
+          allow(@listener).to receive(:login_watch) { "none" }
+          expect(Login.wants_announce(@listener, @connector)).to eq false
         end
         
         it "should not want announce if friends-only and have not friended a char" do
-          @listener.stub(:login_watch) { "friends" }
-          @listener.stub(:is_friend?).with(@connector) { false }
-          Login.wants_announce(@listener, @connector).should eq false
+          allow(@listener).to receive(:login_watch) { "friends" }
+          allow(@listener).to receive(:is_friend?).with(@connector) { false }
+          expect(Login.wants_announce(@listener, @connector)).to eq false
         end
         
         it "should want announce if friends-only and have friended a  handle" do
-          @listener.stub(:login_watch) { "friends" }
-          @listener.stub(:is_friend?).with(@connector) { true }
-          Login.wants_announce(@listener, @connector).should eq true
+          allow(@listener).to receive(:login_watch) { "friends" }
+          allow(@listener).to receive(:is_friend?).with(@connector) { true }
+          expect(Login.wants_announce(@listener, @connector)).to eq true
         end
         
       end

--- a/plugins/manage/specs/destroy_cmd_specs.rb
+++ b/plugins/manage/specs/destroy_cmd_specs.rb
@@ -7,24 +7,24 @@ module AresMUSH
       before do
         @client = double
         @handler = DestroyCmd.new(@client, nil, nil)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
         @game = double
-        Game.stub(:master) { @game }
+        allow(Game).to receive(:master) { @game }
       end
       
       describe :handle do
         before do
-          Rooms.stub(:is_special_room?) { false }
-          @game.stub(:is_special_char?) { false }
-          Manage.stub(:can_manage_object?) { true }
-          FS3Combat.stub(:is_in_combat?) { false }
+          allow(Rooms).to receive(:is_special_room?) { false }
+          allow(@game).to receive(:is_special_char?) { false }
+          allow(Manage).to receive(:can_manage_object?) { true }
+          allow(FS3Combat).to receive(:is_in_combat?) { false }
           @handler.name = "foo"
         end
         
         context "not found" do
           it "should emit failure if the target is not found" do
-            AnyTargetFinder.stub(:find).with("foo", @enactor) { FindResult.new(nil, "an error") }
-            @client.should_receive(:emit_failure).with("an error")
+            allow(AnyTargetFinder).to receive(:find).with("foo", @enactor) { FindResult.new(nil, "an error") }
+            expect(@client).to receive(:emit_failure).with("an error")
             @handler.handle
           end
         end
@@ -32,9 +32,9 @@ module AresMUSH
         context "special room" do
           it "should emit failure if trying to destroy a special room" do
             target = double
-            AnyTargetFinder.stub(:find) { FindResult.new(target, nil) }
-            Rooms.stub(:is_special_room?).with(target) { true }
-            @client.should_receive(:emit_failure).with("manage.cannot_destroy_special_rooms")
+            allow(AnyTargetFinder).to receive(:find) { FindResult.new(target, nil) }
+            allow(Rooms).to receive(:is_special_room?).with(target) { true }
+            expect(@client).to receive(:emit_failure).with("manage.cannot_destroy_special_rooms")
             @handler.handle
           end
         end
@@ -42,28 +42,28 @@ module AresMUSH
         context "special char" do
           it "should emit failure if trying to destroy a special char" do
             target = double
-            AnyTargetFinder.stub(:find) { FindResult.new(target, nil) }
-            @game.stub(:is_special_char?).with(target) { true }
-            @client.should_receive(:emit_failure).with("manage.cannot_destroy_special_chars")
+            allow(AnyTargetFinder).to receive(:find) { FindResult.new(target, nil) }
+            allow(@game).to receive(:is_special_char?).with(target) { true }
+            expect(@client).to receive(:emit_failure).with("manage.cannot_destroy_special_chars")
             @handler.handle
           end
         end
         
         it "should emit failure if trying to destroy a char in combat" do
           target = double
-          target.stub(:class) { "AresMUSH::Character"}
-          AnyTargetFinder.stub(:find) { FindResult.new(target, nil) }
-          FS3Combat.stub(:is_in_combat?).with(target) { true }
-          @client.should_receive(:emit_failure).with("manage.cannot_destroy_in_combat")
+          allow(target).to receive(:class) { "AresMUSH::Character"}
+          allow(AnyTargetFinder).to receive(:find) { FindResult.new(target, nil) }
+          allow(FS3Combat).to receive(:is_in_combat?).with(target) { true }
+          expect(@client).to receive(:emit_failure).with("manage.cannot_destroy_in_combat")
           @handler.handle
         end
         
         context "not allowed" do
           it "should emit failure if the char doesn't have permission" do
             target = double
-            AnyTargetFinder.stub(:find) { FindResult.new(target, nil) }
-            Manage.should_receive(:can_manage_object?).with(@enactor, target) { false }
-            @client.should_receive(:emit_failure).with("dispatcher.not_allowed")
+            allow(AnyTargetFinder).to receive(:find) { FindResult.new(target, nil) }
+            expect(Manage).to receive(:can_manage_object?).with(@enactor, target) { false }
+            expect(@client).to receive(:emit_failure).with("dispatcher.not_allowed")
             @handler.handle
           end
         end
@@ -71,21 +71,21 @@ module AresMUSH
         context "success" do
           before do
             @target = Character.new
-            @target.stub(:id) { 1 }
-            @target.stub(:print_json) { "" }
+            allow(@target).to receive(:id) { 1 }
+            allow(@target).to receive(:print_json) { "" }
             results = FindResult.new(@target)
-            AnyTargetFinder.stub(:find) { results }
-            @client.stub(:program=)
-            @client.stub(:emit)
+            allow(AnyTargetFinder).to receive(:find) { results }
+            allow(@client).to receive(:program=)
+            allow(@client).to receive(:emit)
           end
           
           it "should set the program to the destroy target" do
-            @client.should_receive(:program=).with( { :destroy_target => "#C-1", :destroy_class => AresMUSH::Character } )
+            expect(@client).to receive(:program=).with( { :destroy_target => "#C-1", :destroy_class => AresMUSH::Character } )
             @handler.handle
           end
           
           it "should emit the confirmation message" do
-            @client.should_receive(:emit).with("%lh\nmanage.confirm_object_destroy\n%lf")
+            expect(@client).to receive(:emit).with("%lh\nmanage.confirm_object_destroy\n%lf")
             @handler.handle
           end
         end

--- a/plugins/manage/specs/destroy_confirm_cmd_specs.rb
+++ b/plugins/manage/specs/destroy_confirm_cmd_specs.rb
@@ -7,65 +7,65 @@ module AresMUSH
         @client = double
         @enactor = double
         @handler = DestroyConfirmCmd.new(@client, nil, @enactor)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
         @game = double
-        Game.stub(:master) { @game }
+        allow(Game).to receive(:master) { @game }
       end
             
       describe :handle do
         before do
           @target = Character.new
-          @target.stub(:id) { "X" }
-          Login.stub(:is_online?).with(@target) { false }
-          ClassTargetFinder.stub(:find).with("X", @target.class, @enactor) { FindResult.new(@target, nil) }
-          @client.stub(:program) { { :destroy_target => @target.id, 
+          allow(@target).to receive(:id) { "X" }
+          allow(Login).to receive(:is_online?).with(@target) { false }
+          allow(ClassTargetFinder).to receive(:find).with("X", @target.class, @enactor) { FindResult.new(@target, nil) }
+          allow(@client).to receive(:program) { { :destroy_target => @target.id, 
                :destroy_class => @target.class,
                :something_else => "x" } }
-          Manage.stub(:can_manage_object?) { true }
+          allow(Manage).to receive(:can_manage_object?) { true }
           @handler.parse_args
         end
         
         context "failures" do
           it "should emit failure if the client is not doing a destroy" do
-            @client.stub(:program) { {} }
-            @client.should_receive(:emit_failure).with("manage.no_destroy_in_progress")
+            allow(@client).to receive(:program) { {} }
+            expect(@client).to receive(:emit_failure).with("manage.no_destroy_in_progress")
             @handler.handle
           end
 
           it "should emit failure if trying to destroy a char who's online" do
-            Login.stub(:is_online?).with(@target) { true }
-            @client.should_receive(:emit_failure).with("manage.cannot_destroy_online")
+            allow(Login).to receive(:is_online?).with(@target) { true }
+            expect(@client).to receive(:emit_failure).with("manage.cannot_destroy_online")
             @handler.handle
           end
           
           it "should emit failure if the char doesn't have permission" do
-            Manage.should_receive(:can_manage_object?) { false }
-            @client.should_receive(:emit_failure).with("dispatcher.not_allowed")
+            expect(Manage).to receive(:can_manage_object?) { false }
+            expect(@client).to receive(:emit_failure).with("dispatcher.not_allowed")
             @handler.handle
           end
         end
         
         context "success" do
           before do
-            @client.stub(:emit_success)
-            @target.stub(:delete) {}
-            @target.stub(:name) { "name" }
+            allow(@client).to receive(:emit_success)
+            allow(@target).to receive(:delete) {}
+            allow(@target).to receive(:name) { "name" }
           end
           
           it "should destroy the target" do
-            @target.should_receive(:delete)
+            expect(@target).to receive(:delete)
             @handler.handle
           end
           
           it "should emit success" do
-            @client.should_receive(:emit_success).with('manage.object_destroyed')
+            expect(@client).to receive(:emit_success).with('manage.object_destroyed')
             @handler.handle
           end
           
           it "should reset the client program" do
             @handler.handle
-            @client.program[:something_else].should eq "x"
-            @client.program[:delete_cmd].should be_nil
+            expect(@client.program[:something_else]).to eq "x"
+            expect(@client.program[:delete_cmd]).to be_nil
           end 
         
           context "destroying a room" do
@@ -73,28 +73,28 @@ module AresMUSH
 
               # Stub out welcome room
               @welcome_room = double
-              @game.stub(:welcome_room) { @welcome_room }
+              allow(@game).to receive(:welcome_room) { @welcome_room }
 
               # Pretend the target is a room
-              @target.stub(:class) { Room }
-              ClassTargetFinder.stub(:find).with("X", @target.class, @enactor) { FindResult.new(@target, nil) }
+              allow(@target).to receive(:class) { Room }
+              allow(ClassTargetFinder).to receive(:find).with("X", @target.class, @enactor) { FindResult.new(@target, nil) }
 
               @char_in_room = double
-              @target.stub(:characters) { [@char_in_room] }
+              allow(@target).to receive(:characters) { [@char_in_room] }
             end
           
             it "should tell an online char they're being moved and move them" do
               # Match up a client to the character
               client_in_room = double
-              Login.stub(:find_client).with(@char_in_room) { client_in_room }
-              client_in_room.should_receive(:emit_ooc).with("manage.room_being_destroyed")
-              Rooms.should_receive(:send_to_welcome_room).with(client_in_room, @char_in_room)
+              allow(Login).to receive(:find_client).with(@char_in_room) { client_in_room }
+              expect(client_in_room).to receive(:emit_ooc).with("manage.room_being_destroyed")
+              expect(Rooms).to receive(:send_to_welcome_room).with(client_in_room, @char_in_room)
               @handler.handle
             end
           
             it "should move them to the welcome room" do
-              Login.stub(:find_client).with(@char_in_room) { nil }
-              Rooms.should_receive(:send_to_welcome_room).with(nil, @char_in_room)
+              allow(Login).to receive(:find_client).with(@char_in_room) { nil }
+              expect(Rooms).to receive(:send_to_welcome_room).with(nil, @char_in_room)
               @handler.handle
             end
           end

--- a/plugins/manage/specs/load_config_cmd_specs.rb
+++ b/plugins/manage/specs/load_config_cmd_specs.rb
@@ -8,37 +8,37 @@ module AresMUSH
       before do
         @client = double
         @handler = LoadConfigCmd.new(@client, nil, nil)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
         stub_global_objects
-        dispatcher.stub(:queue_event)
+        allow(dispatcher).to receive(:queue_event)
       end
             
       describe :handle do
         before do
-          config_reader.stub(:clear_config)
-          config_reader.stub(:load_game_config)
-          config_reader.stub(:validate_game_config)
-          help_reader.stub(:load_game_help)
+          allow(config_reader).to receive(:clear_config)
+          allow(config_reader).to receive(:load_game_config)
+          allow(config_reader).to receive(:validate_game_config)
+          allow(help_reader).to receive(:load_game_help)
           @plugin = double
-          plugin_manager.stub(:plugins) { [@plugin] }
+          allow(plugin_manager).to receive(:plugins) { [@plugin] }
         end
         
         it "should reset and load the game config" do           
-          config_reader.should_receive(:load_game_config) {}
-          @client.should_receive(:emit_success).with('manage.config_loaded')
+          expect(config_reader).to receive(:load_game_config) {}
+          expect(@client).to receive(:emit_success).with('manage.config_loaded')
           @handler.handle
         end
         
         it "should handle errors from game config" do
-          config_reader.should_receive(:validate_game_config).and_raise("error")
-          @client.should_receive(:emit_failure).with('manage.game_config_invalid')
+          expect(config_reader).to receive(:validate_game_config).and_raise("error")
+          expect(@client).to receive(:emit_failure).with('manage.game_config_invalid')
           @handler.handle
         end    
         
         it "should send the config updated event" do
-          @client.should_receive(:emit_success).with('manage.config_loaded')
-          dispatcher.should_receive(:queue_event) do |event|
-            event.class.should eq ConfigUpdatedEvent
+          expect(@client).to receive(:emit_success).with('manage.config_loaded')
+          expect(dispatcher).to receive(:queue_event) do |event|
+            expect(event.class).to eq ConfigUpdatedEvent
           end
           @handler.handle          
         end

--- a/plugins/manage/specs/load_locale_cmd_specs.rb
+++ b/plugins/manage/specs/load_locale_cmd_specs.rb
@@ -8,25 +8,25 @@ module AresMUSH
       before do
         @client = double
         @handler = LoadLocaleCmd.new(@client, nil, nil)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
         stub_global_objects
       end
             
       describe :handle do        
         it "should reload the locale and notify client" do
           plugin = double
-          plugin_manager.stub(:plugins) { [plugin] }
+          allow(plugin_manager).to receive(:plugins) { [plugin] }
 
-          locale.should_receive(:reset_load_path)
-          plugin_manager.should_receive(:load_plugin_locale).with( plugin ) {}
-          locale.should_receive(:reload)
-          @client.should_receive(:emit_success).with('manage.locale_loaded')
+          expect(locale).to receive(:reset_load_path)
+          expect(plugin_manager).to receive(:load_plugin_locale).with( plugin ) {}
+          expect(locale).to receive(:reload)
+          expect(@client).to receive(:emit_success).with('manage.locale_loaded')
           @handler.handle
         end
         
         it "should handle errors from locale load" do
-          locale.should_receive(:reset_load_path) { raise "Error" }
-          @client.should_receive(:emit_failure).with('manage.error_loading_locale')
+          expect(locale).to receive(:reset_load_path) { raise "Error" }
+          expect(@client).to receive(:emit_failure).with('manage.error_loading_locale')
           @handler.handle
         end     
       end

--- a/plugins/manage/specs/load_plugin_cmd_specs.rb
+++ b/plugins/manage/specs/load_plugin_cmd_specs.rb
@@ -8,7 +8,7 @@ module AresMUSH
       before do
         @client = double
         @handler = LoadPluginCmd.new(@client, nil, nil)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
         stub_global_objects
       end
       
@@ -17,84 +17,84 @@ module AresMUSH
         before do
           @handler.load_target = "foo"
             
-          @client.stub(:emit_success)
-          @client.stub(:emit_ooc)
-          plugin_manager.stub(:load_plugin)
-          plugin_manager.stub(:unload_plugin)
-          config_reader.stub(:validate_game_config)
-          config_reader.stub(:load_game_config)
-          Help.stub(:reload_help)
-          locale.stub(:reload)
-          Manage.stub(:can_manage_game?) { true }
-          dispatcher.stub(:queue_event)
+          allow(@client).to receive(:emit_success)
+          allow(@client).to receive(:emit_ooc)
+          allow(plugin_manager).to receive(:load_plugin)
+          allow(plugin_manager).to receive(:unload_plugin)
+          allow(config_reader).to receive(:validate_game_config)
+          allow(config_reader).to receive(:load_game_config)
+          allow(Help).to receive(:reload_help)
+          allow(locale).to receive(:reload)
+          allow(Manage).to receive(:can_manage_game?) { true }
+          allow(dispatcher).to receive(:queue_event)
         end
           
         it "should load the plugin" do
-          plugin_manager.should_receive(:load_plugin).with("foo")
+          expect(plugin_manager).to receive(:load_plugin).with("foo")
           @handler.handle
         end
           
         it "should unload the plugin" do
-          plugin_manager.should_receive(:unload_plugin).with("foo")
+          expect(plugin_manager).to receive(:unload_plugin).with("foo")
           @handler.handle
         end
           
         it "should notify the client" do
-          @client.should_receive(:emit_success).with('manage.plugin_loaded')
+          expect(@client).to receive(:emit_success).with('manage.plugin_loaded')
           @handler.handle
         end
           
         it "should reload the help" do
-          Help.should_receive(:reload_help)
+          expect(Help).to receive(:reload_help)
           @handler.handle
         end
         
         it "should reload the config" do
-          config_reader.should_receive(:validate_game_config)
-          config_reader.should_receive(:load_game_config)
+          expect(config_reader).to receive(:validate_game_config)
+          expect(config_reader).to receive(:load_game_config)
           @handler.handle
         end
           
         it "should notify client if plugin not found" do
-          plugin_manager.stub(:load_plugin) { raise SystemNotFoundException }
-          @client.should_receive(:emit_failure).with('manage.plugin_not_found')
+          allow(plugin_manager).to receive(:load_plugin) { raise SystemNotFoundException }
+          expect(@client).to receive(:emit_failure).with('manage.plugin_not_found')
           @handler.handle
         end
           
         it "should notify client if plugin load has an error" do
-          plugin_manager.stub(:load_plugin) { raise "Error" }
-          @client.should_receive(:emit_failure).with('manage.error_loading_plugin')
+          allow(plugin_manager).to receive(:load_plugin) { raise "Error" }
+          expect(@client).to receive(:emit_failure).with('manage.error_loading_plugin')
           @handler.handle
         end
         
         it "should send the config updated event" do
-          dispatcher.should_receive(:queue_event) do |event|
-            event.class.should eq ConfigUpdatedEvent
+          expect(dispatcher).to receive(:queue_event) do |event|
+            expect(event.class).to eq ConfigUpdatedEvent
           end
           @handler.handle
         end
         
         it "should fail if no permissions" do
-          Manage.stub(:can_manage_game?).with(@enactor) { false }
-          @client.should_receive(:emit_failure).with('dispatcher.not_allowed')
+          allow(Manage).to receive(:can_manage_game?).with(@enactor) { false }
+          expect(@client).to receive(:emit_failure).with('dispatcher.not_allowed')
           @handler.handle
         end
         
         it "should succeed and alert permissions are mis-configured" do
-          Manage.stub(:can_manage_game?).with(@enactor) { raise "Error" }
-          @client.should_receive(:emit_failure).with('manage.management_config_messed_up')
-          plugin_manager.should_receive(:load_plugin).with("foo")
+          allow(Manage).to receive(:can_manage_game?).with(@enactor) { raise "Error" }
+          expect(@client).to receive(:emit_failure).with('manage.management_config_messed_up')
+          expect(plugin_manager).to receive(:load_plugin).with("foo")
           @handler.handle
         end
         
         it "should still load even if the unload failed" do
-          plugin_manager.stub(:unload_plugin) { raise SystemNotFoundException }
-          plugin_manager.should_receive(:load_plugin).with("foo")
+          allow(plugin_manager).to receive(:unload_plugin) { raise SystemNotFoundException }
+          expect(plugin_manager).to receive(:load_plugin).with("foo")
           @handler.handle
         end
         
         it "should reload locale" do
-          locale.should_receive(:reload)
+          expect(locale).to receive(:reload)
           @handler.handle
         end
         

--- a/plugins/manage/specs/shared_specs.rb
+++ b/plugins/manage/specs/shared_specs.rb
@@ -4,16 +4,16 @@ module AresMUSH
       describe :can_manage_object? do
         before do
           @admin = double
-          @admin.stub(:has_permission?).with("manage_game") { true }
-          @admin.stub(:has_permission?).with("build") { false }
+          allow(@admin).to receive(:has_permission?).with("manage_game") { true }
+          allow(@admin).to receive(:has_permission?).with("build") { false }
 
           @builder = double
-          @builder.stub(:has_permission?).with("manage_game") { false }
-          @builder.stub(:has_permission?).with("build") { true }
+          allow(@builder).to receive(:has_permission?).with("manage_game") { false }
+          allow(@builder).to receive(:has_permission?).with("build") { true }
 
           @player = double
-          @player.stub(:has_permission?).with("manage_game") { false }
-          @player.stub(:has_permission?).with("build") { false }
+          allow(@player).to receive(:has_permission?).with("manage_game") { false }
+          allow(@player).to receive(:has_permission?).with("build") { false }
           
           @room = Room.new
           @exit = Exit.new
@@ -21,35 +21,35 @@ module AresMUSH
         end
           
         it "should allow someone with room permissions to manage a room" do
-          Manage.can_manage_object?(@builder, @room).should be true
+          expect(Manage.can_manage_object?(@builder, @room)).to be true
         end
 
         it "should allow someone with game permissions to manage a room" do
-          Manage.can_manage_object?(@admin, @room).should be true
+          expect(Manage.can_manage_object?(@admin, @room)).to be true
         end
 
         it "should not allow someone without permissions to manage a room" do
-          Manage.can_manage_object?(@player, @room).should be false
+          expect(Manage.can_manage_object?(@player, @room)).to be false
         end
 
         it "should allow someone with room permissions to manage an exit" do
-          Manage.can_manage_object?(@builder, @exit).should be true
+          expect(Manage.can_manage_object?(@builder, @exit)).to be true
         end
 
         it "should allow someone with game permissions to manage an exit" do
-          Manage.can_manage_object?(@admin, @exit).should be true
+          expect(Manage.can_manage_object?(@admin, @exit)).to be true
         end
 
         it "should not allow someone without permissions to manage a room" do
-          Manage.can_manage_object?(@player, @exit).should be false
+          expect(Manage.can_manage_object?(@player, @exit)).to be false
         end
 
         it "should allow someone with game permissions to manage a character" do
-          Manage.can_manage_object?(@admin, @char).should be true
+          expect(Manage.can_manage_object?(@admin, @char)).to be true
         end
 
         it "should not allow someone with char permissions to manage a character" do
-          Manage.can_manage_object?(@builder, @char).should be false
+          expect(Manage.can_manage_object?(@builder, @char)).to be false
         end
       end
     end

--- a/plugins/manage/specs/unload_plugin_cmd_specs.rb
+++ b/plugins/manage/specs/unload_plugin_cmd_specs.rb
@@ -8,7 +8,7 @@ module AresMUSH
       before do
         @client = double
         @handler = UnloadPluginCmd.new(@client, nil, nil)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
         stub_global_objects
       end
       
@@ -17,30 +17,30 @@ module AresMUSH
         before do
           @handler.load_target = "foo"
             
-          @client.stub(:emit_success)
-          plugin_manager.stub(:unload_plugin)
-          Help.stub(:reload_help)
+          allow(@client).to receive(:emit_success)
+          allow(plugin_manager).to receive(:unload_plugin)
+          allow(Help).to receive(:reload_help)
         end
           
         it "should unload the plugin" do
-          plugin_manager.should_receive(:unload_plugin).with("foo")
+          expect(plugin_manager).to receive(:unload_plugin).with("foo")
           @handler.handle
         end
           
         it "should notify the client" do
-          @client.should_receive(:emit_success).with('manage.plugin_unloaded')
+          expect(@client).to receive(:emit_success).with('manage.plugin_unloaded')
           @handler.handle
         end
 
         it "should notify client if plugin not found" do
-          plugin_manager.stub(:unload_plugin) { raise SystemNotFoundException }
-          @client.should_receive(:emit_failure).with('manage.plugin_not_found')
+          allow(plugin_manager).to receive(:unload_plugin) { raise SystemNotFoundException }
+          expect(@client).to receive(:emit_failure).with('manage.plugin_not_found')
           @handler.handle
         end
           
         it "should notify client if plugin unload has an error" do
-          plugin_manager.stub(:unload_plugin) { raise "Error" }
-          @client.should_receive(:emit_failure).with('manage.error_unloading_plugin')
+          allow(plugin_manager).to receive(:unload_plugin) { raise "Error" }
+          expect(@client).to receive(:emit_failure).with('manage.error_unloading_plugin')
           @handler.handle
         end
       end

--- a/plugins/page/specs/page_specs.rb
+++ b/plugins/page/specs/page_specs.rb
@@ -6,38 +6,38 @@ module AresMUSH
   
       before do
         @enactor = double
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
             
       describe :parse_args do
         it "should crack a name and message" do
           handler = PageCmd.new(@client, Command.new("page bob=something"), @enactor)
           handler.parse_args
-          handler.names.should eq [ "bob" ]
-          handler.message.should eq "something"
+          expect(handler.names).to eq [ "bob" ]
+          expect(handler.message).to eq "something"
         end
         
         it "should crack a list of multiple names" do
           handler = PageCmd.new(@client, Command.new("page bob harvey=something"), @enactor)
           handler.parse_args
-          handler.names.should eq [ "bob", "harvey" ]
-          handler.message.should eq "something"
+          expect(handler.names).to eq [ "bob", "harvey" ]
+          expect(handler.message).to eq "something"
         end
         
         it "should use the lastpaged if no name specified" do
           handler = PageCmd.new(@client, Command.new("page something"), @enactor)
-          @enactor.stub(:last_paged) { ["bob", "harvey"] }
+          allow(@enactor).to receive(:last_paged) { ["bob", "harvey"] }
           handler.parse_args
-          handler.names.should eq [ "bob", "harvey" ]
-          handler.message.should eq "something"
+          expect(handler.names).to eq [ "bob", "harvey" ]
+          expect(handler.message).to eq "something"
         end
         
         it "should use lastpaged for a message beginning with =" do
           handler = PageCmd.new(@client, Command.new("page =something"), @enactor)
-          @enactor.stub(:last_paged) { ["bob", "harvey"] }
+          allow(@enactor).to receive(:last_paged) { ["bob", "harvey"] }
           handler.parse_args
-          handler.names.should eq [ "bob", "harvey" ]
-          handler.message.should eq "something"
+          expect(handler.names).to eq [ "bob", "harvey" ]
+          expect(handler.message).to eq "something"
         end
         
       end

--- a/plugins/rooms/spec/interface_specs.rb
+++ b/plugins/rooms/spec/interface_specs.rb
@@ -11,49 +11,49 @@ module AresMUSH
           
           @client = double
           @char = double
-          SpecHelpers.setup_mock_client(@client, @char)
+          setup_mock_client(@client, @char)
           
-          @char.stub(:room) { @old_room }
+          allow(@char).to receive(:room) { @old_room }
         
-          @old_room.stub(:emit_ooc)
-          @new_room.stub(:emit_ooc)
-          @char.stub(:update)
-          @char.stub(:name) { "Char" }
-          Rooms.stub(:emit_here_desc)
-          Places.stub(:clear_place) {}
-          Status.stub(:update_last_ic_location) {}
-          SpecHelpers.stub_translate_for_testing
+          allow(@old_room).to receive(:emit_ooc)
+          allow(@new_room).to receive(:emit_ooc)
+          allow(@char).to receive(:update)
+          allow(@char).to receive(:name) { "Char" }
+          allow(Rooms).to receive(:emit_here_desc)
+          allow(Places).to receive(:clear_place) {}
+          allow(Status).to receive(:update_last_ic_location) {}
+          stub_translate_for_testing
         end
       
         it "should emit leaving to the current room" do
-          Locale.stub(:translate).with("rooms.char_has_left", :name => "Char") { "has left" }
-          @old_room.should_receive(:emit_ooc).with('has left')
+          allow(Locale).to receive(:translate).with("rooms.char_has_left", :name => "Char") { "has left" }
+          expect(@old_room).to receive(:emit_ooc).with('has left')
           Rooms.move_to(@client, @char, @new_room)
         end
       
         it "should emit arriving to the new room" do
-          Locale.stub(:translate).with("rooms.char_has_arrived", :name => "Char") { "has arrived" }
-          @new_room.should_receive(:emit_ooc).with('has arrived')
+          allow(Locale).to receive(:translate).with("rooms.char_has_arrived", :name => "Char") { "has arrived" }
+          expect(@new_room).to receive(:emit_ooc).with('has arrived')
           Rooms.move_to(@client, @char, @new_room)
         end
       
         it "should update the char location" do
-          @char.should_receive(:update).with(room: @new_room)
+          expect(@char).to receive(:update).with(room: @new_room)
           Rooms.move_to(@client, @char, @new_room)
         end
       
         it "should emit the new room desc" do
-          Rooms.should_receive(:emit_here_desc).with(@client, @char)
+          expect(Rooms).to receive(:emit_here_desc).with(@client, @char)
           Rooms.move_to(@client, @char, @new_room)
         end
         
         it "should update last IC loc" do
-          Status.should_receive(:update_last_ic_location) {}
+          expect(Status).to receive(:update_last_ic_location) {}
           Rooms.move_to(@client, @char, @new_room)
         end
         
         it "should clear out their place" do
-          Places.should_receive(:clear_place).with(@char) {}
+          expect(Places).to receive(:clear_place).with(@char) {}
           Rooms.move_to(@client, @char, @new_room)
         end
       end

--- a/plugins/rooms/spec/login_events_specs.rb
+++ b/plugins/rooms/spec/login_events_specs.rb
@@ -5,50 +5,50 @@ module AresMUSH
     describe Rooms do
       before do
         @client = double(Client)
-        @client.stub(:name) { "Bob" }
+        allow(@client).to receive(:name) { "Bob" }
 
         @room = double
-        @client.stub(:room) { @room }
+        allow(@client).to receive(:room) { @room }
 
         @game = double
-        Game.stub(:master) { @game }
+        allow(Game).to receive(:master) { @game }
 
-        Describe.stub(:desc_template)
-        @room.stub(:emit_ooc)
+        allow(Describe).to receive(:desc_template)
+        allow(@room).to receive(:emit_ooc)
         
         @char = double
         @char_id = 111
-        Character.stub(:[]).with(@char_id) { @char  }
+        allow(Character).to receive(:[]).with(@char_id) { @char  }
         
-        AresMUSH::Locale.stub(:translate).with("rooms.char_has_arrived", { :name => "Bob" }) { "char_has_arrived" }
+        allow(AresMUSH::Locale).to receive(:translate).with("rooms.char_has_arrived", { :name => "Bob" }) { "char_has_arrived" }
       end
       
       describe :on_char_connected_event do      
         it "should emit the desc of the char's last location" do
-          @client.stub(:char) { @char }
+          allow(@client).to receive(:char) { @char }
           @login = CharConnectedEventHandler.new
-          Rooms.should_receive(:emit_here_desc).with(@client, @char)
+          expect(Rooms).to receive(:emit_here_desc).with(@client, @char)
           @login.on_event CharConnectedEvent.new(@client, @char_id)
         end
       end
       
       describe :on_char_disconnected_event do   
         before do
-          @client.stub(:char) { @char }
+          allow(@client).to receive(:char) { @char }
           @welcome_room = double
-          @game.stub(:welcome_room) { @welcome_room }
+          allow(@game).to receive(:welcome_room) { @welcome_room }
           @login = CharDisconnectedEventHandler.new
         end
            
         it "should send guests home to the welcome room" do
-          @char.stub(:is_guest?) { true }
-          Rooms.should_receive(:move_to).with(@client, @char, @welcome_room)
+          allow(@char).to receive(:is_guest?) { true }
+          expect(Rooms).to receive(:move_to).with(@client, @char, @welcome_room)
           @login.on_event CharDisconnectedEvent.new(@client, @char_id)
         end
 
         it "should not move around regular characters" do
-          @char.stub(:is_guest?) { false }
-          Rooms.should_not_receive(:move_to)
+          allow(@char).to receive(:is_guest?) { false }
+          expect(Rooms).to_not receive(:move_to)
           @login.on_event CharDisconnectedEvent.new(@client, @char_id)
         end
       end

--- a/plugins/rooms/spec/shared_specs.rb
+++ b/plugins/rooms/spec/shared_specs.rb
@@ -5,21 +5,21 @@ module AresMUSH
         before do
           @source = double
           @dest = double
-          @source.stub(:name) { "source" }
-          @dest.stub(:name) { "dest" }
-          SpecHelpers.stub_translate_for_testing
+          allow(@source).to receive(:name) { "source" }
+          allow(@dest).to receive(:name) { "dest" }
+          stub_translate_for_testing
         end
       
         it "should return error if exit already exists." do
-          @source.should_receive(:has_exit?).with("AE") { true }
-          Exit.should_not_receive(:create)
-          Rooms.open_exit("AE", @source, @dest).should eq "rooms.exit_already_exists"
+          expect(@source).to receive(:has_exit?).with("AE") { true }
+          expect(Exit).to_not receive(:create)
+          expect(Rooms.open_exit("AE", @source, @dest)).to eq "rooms.exit_already_exists"
         end
       
         it "should create the exit" do
-          @source.stub(:has_exit?) { false }
-          Exit.should_receive(:create).with( { :name => "AE", :source => @source, :dest => @dest } )
-          Rooms.open_exit("AE", @source, @dest).should eq "rooms.exit_created"
+          allow(@source).to receive(:has_exit?) { false }
+          expect(Exit).to receive(:create).with( { :name => "AE", :source => @source, :dest => @dest } )
+          expect(Rooms.open_exit("AE", @source, @dest)).to eq "rooms.exit_created"
         end
       end
     
@@ -27,23 +27,23 @@ module AresMUSH
       describe :find_destination do
         before do
           @room = double
-          @room.stub(:name_upcase) { "SOMEWHERE" }
+          allow(@room).to receive(:name_upcase) { "SOMEWHERE" }
           @rooms = [ @room ]
           @enactor = double
-          Room.stub(:all) { @rooms }
+          allow(Room).to receive(:all) { @rooms }
         end
         
         it "should find the room when the destination is a char" do
           other_char = double
-          other_char.stub(:room) { @room }
-          ClassTargetFinder.should_receive(:find).with("somewhere", Character, @enactor) { FindResult.new(other_char, nil) }
-          Rooms.find_destination("somewhere", @enactor, true).should eq [@room]
+          allow(other_char).to receive(:room) { @room }
+          expect(ClassTargetFinder).to receive(:find).with("somewhere", Character, @enactor) { FindResult.new(other_char, nil) }
+          expect(Rooms.find_destination("somewhere", @enactor, true)).to eq [@room]
         end
         
         it "should find the room when the destination is a room with an exact name match" do
-          ClassTargetFinder.should_receive(:find).with("somewhere", Character, @enactor) { FindResult.new(nil, "error") }
-          ClassTargetFinder.should_receive(:find).with("somewhere", Room, @enactor) { FindResult.new(@room, nil) }
-          Rooms.find_destination("somewhere", @enactor, true).should eq [@room]
+          expect(ClassTargetFinder).to receive(:find).with("somewhere", Character, @enactor) { FindResult.new(nil, "error") }
+          expect(ClassTargetFinder).to receive(:find).with("somewhere", Room, @enactor) { FindResult.new(@room, nil) }
+          expect(Rooms.find_destination("somewhere", @enactor, true)).to eq [@room]
         end
       end
       
@@ -53,10 +53,10 @@ module AresMUSH
           char = double
           room = double
           template = double
-          Describe.should_receive(:desc_template).with(room, char) { template }
-          template.should_receive(:render) { "room desc" }
-          char.stub(:room) { room }
-          client.should_receive(:emit).with("room desc")
+          expect(Describe).to receive(:desc_template).with(room, char) { template }
+          expect(template).to receive(:render) { "room desc" }
+          allow(char).to receive(:room) { room }
+          expect(client).to receive(:emit).with("room desc")
           Rooms.emit_here_desc(client, char)
         end
       end   

--- a/plugins/scenes/specs/pose_catcher_specs.rb
+++ b/plugins/scenes/specs/pose_catcher_specs.rb
@@ -6,16 +6,16 @@ module AresMUSH
         @client = double
         @enactor = double
         @handler = PoseCatcherCmd.new(@client, Command.new(":test"), @enactor)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
             
       describe :handle do
         it "should emit to the room" do
           room = double
-          @enactor.stub(:room) { room }
-          @enactor.stub(:name) { "Bob" }
-          PoseFormatter.should_receive(:format).with("Bob", ":test") { "Bob test"}
-          Scenes.should_receive(:emit_pose).with(@enactor, "Bob test", false, false)
+          allow(@enactor).to receive(:room) { room }
+          allow(@enactor).to receive(:name) { "Bob" }
+          expect(PoseFormatter).to receive(:format).with("Bob", ":test") { "Bob test"}
+          expect(Scenes).to receive(:emit_pose).with(@enactor, "Bob test", false, false)
           @handler.handle
         end
       end

--- a/plugins/scenes/specs/pose_cmd_specs.rb
+++ b/plugins/scenes/specs/pose_cmd_specs.rb
@@ -8,40 +8,40 @@ module AresMUSH
         @client = double
         @enactor = double
         @handler = PoseCmd.new(@client, Command.new("pose a message"), @enactor)
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
       
       describe :handle do
         it "should emit to the room" do
           room = double
-          @client.stub(:room) { room }
-          @handler.stub(:message) { "a message" }
-          Scenes.should_receive(:emit_pose).with(@enactor, "a message", false, false)
+          allow(@client).to receive(:room) { room }
+          allow(@handler).to receive(:message) { "a message" }
+          expect(Scenes).to receive(:emit_pose).with(@enactor, "a message", false, false)
           @handler.handle
         end
       end
       
       describe :message do
         before do
-          @enactor.stub(:name) { "Bob" }          
+          allow(@enactor).to receive(:name) { "Bob" }          
         end
         
         it "should format an emit message" do
           @handler = PoseCmd.new(@client, Command.new("emit test"), @enactor)
-          PoseFormatter.should_receive(:format).with("Bob", "\\test") { "formatted msg" }
-          @handler.message.should eq "formatted msg"
+          expect(PoseFormatter).to receive(:format).with("Bob", "\\test") { "formatted msg" }
+          expect(@handler.message).to eq "formatted msg"
         end
 
         it "should format a say message" do
           @handler = PoseCmd.new(@client, Command.new("say test"), @enactor)
-          PoseFormatter.should_receive(:format).with("Bob", "\"test") { "formatted msg" }
-          @handler.message.should eq "formatted msg"
+          expect(PoseFormatter).to receive(:format).with("Bob", "\"test") { "formatted msg" }
+          expect(@handler.message).to eq "formatted msg"
         end
 
         it "should format a pose message" do
           @handler = PoseCmd.new(@client, Command.new("pose test"), @enactor)
-          PoseFormatter.should_receive(:format).with("Bob", ":test") { "formatted msg" }
-          @handler.message.should eq "formatted msg"
+          expect(PoseFormatter).to receive(:format).with("Bob", ":test") { "formatted msg" }
+          expect(@handler.message).to eq "formatted msg"
         end
       end     
     end

--- a/plugins/scenes/specs/pose_format_specs.rb
+++ b/plugins/scenes/specs/pose_format_specs.rb
@@ -7,98 +7,98 @@ module AresMUSH
         before do
           @char = double
           @enactor = double
-          @enactor.stub(:name) { "Bob" }
-          @char.stub(:pose_quote_color) { nil }
-          @char.stub(:pose_nospoof) { nil }
-          @char.stub(:pose_autospace) { "" }
-          @enactor.stub(:place_title) { "" }
-          SpecHelpers.stub_translate_for_testing
+          allow(@enactor).to receive(:name) { "Bob" }
+          allow(@char).to receive(:pose_quote_color) { nil }
+          allow(@char).to receive(:pose_nospoof) { nil }
+          allow(@char).to receive(:pose_autospace) { "" }
+          allow(@enactor).to receive(:place_title) { "" }
+          stub_translate_for_testing
         end
         
         describe "colorize" do
           before do
-            @char.stub(:pose_quote_color) { "%xh" }
+            allow(@char).to receive(:pose_quote_color) { "%xh" }
           end
           
           it "should handle no quote at front and end" do
             pose = "The cat said, \"I'm going to jump over the brown fox.\"  And then he did.  \"Whee!\" he shouted."
             expected = "The cat said, %xh\"I'm going to jump over the brown fox.\"%xn  And then he did.  %xh\"Whee!\"%xn he shouted."
-            Scenes.custom_format(pose, @char, @enactor).should eq expected
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq expected
           end
           
           it "should handle quote at front but not end" do
             pose = "\"I'm going to jump over the brown fox,\" said the cat. And then he did.  \"Whee!\" he shouted."
             expected = "%xh\"I'm going to jump over the brown fox,\"%xn said the cat. And then he did.  %xh\"Whee!\"%xn he shouted."
-            Scenes.custom_format(pose, @char, @enactor).should eq expected
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq expected
           end
           
           it "should handle quote at end but not front" do
             pose = "The cat said, \"I'm going to jump over the brown fox.\"  And then he did.  \"Whee!\""
             expected = "The cat said, %xh\"I'm going to jump over the brown fox.\"%xn  And then he did.  %xh\"Whee!\"%xn"
-            Scenes.custom_format(pose, @char, @enactor).should eq expected
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq expected
           end
           
           it "should handle quotes at both ends" do
             pose = "\"I'm going to jump over the brown fox,\" said the cat. And then he did.  \"Whee!\""
             expected = "%xh\"I'm going to jump over the brown fox,\"%xn said the cat. And then he did.  %xh\"Whee!\"%xn"
-            Scenes.custom_format(pose, @char, @enactor).should eq expected
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq expected
           end
           
           it "should handle more than two quotes" do
             pose = "The cat said, \"Whee!\" and then \"Whoosh!\" and then \"Wow!\"."
             expected = "The cat said, %xh\"Whee!\"%xn and then %xh\"Whoosh!\"%xn and then %xh\"Wow!\"%xn."
-            Scenes.custom_format(pose, @char, @enactor).should eq expected
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq expected
           end
           
           it "should handle a single quote randomly" do
             pose = "The cat said, \"Whee! and then stopped."
             # Quote gets lost but that's OK for now.
             expected = "The cat said, Whee! and then stopped."
-            Scenes.custom_format(pose, @char, @enactor).should eq expected
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq expected
           end
           
           it "should handle no quotes" do
             pose = "The cat said he was going to jump over the brown fox."
-            Scenes.custom_format(pose, @char, @enactor).should eq pose
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq pose
           end
           
           it "should not die if there's a missing quote" do
             pose = "The cat said, \"Whee! and then \"Whoosh!\" and then \"Wow!\"."
             # Quote gets lost but that's OK for now.
             expected = "The cat said, %xh\"Whee! and then \"%xnWhoosh!%xh\" and then \"%xnWow!."
-            Scenes.custom_format(pose, @char, @enactor).should eq expected
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq expected
           end
           
           it "should not colorize an OOC remark" do
             pose = "The cat said, \"Whee!\" and then \"Whoosh!\" and then \"Wow!\"."
-            Scenes.custom_format(pose, @char, @enactor, false, true).should eq pose
+            expect(Scenes.custom_format(pose, @char, @enactor, false, true)).to eq pose
           end
           
           it "should not colorize if color is blank" do
-            @char.stub(:pose_quote_color) { "" }
+            allow(@char).to receive(:pose_quote_color) { "" }
             pose = "The cat said, \"Whee!\" and then \"Whoosh!\" and then \"Wow!\"."
-            Scenes.custom_format(pose, @char, @enactor).should eq pose
+            expect(Scenes.custom_format(pose, @char, @enactor)).to eq pose
           end
         end
 
         it "should include place title if set" do
-          @enactor.stub(:place_title) { "xxx" }
-          Scenes.custom_format("Test", @char, @enactor).should eq "xxxTest"
+          allow(@enactor).to receive(:place_title) { "xxx" }
+          expect(Scenes.custom_format("Test", @char, @enactor)).to eq "xxxTest"
         end
                 
         it "should include autospace if set" do
-          @char.stub(:pose_autospace) { "%R" }
-          Scenes.custom_format("Test", @char, @enactor).should eq "%RTest"
+          allow(@char).to receive(:pose_autospace) { "%R" }
+          expect(Scenes.custom_format("Test", @char, @enactor)).to eq "%RTest"
         end
         
         it "should include nospoof if set and if an emit" do
-          @char.stub(:pose_nospoof) { true }
-          Scenes.custom_format("Test", @char, @enactor, true).should eq "%xc%% scenes.emit_nospoof_from%xn%RTest"
+          allow(@char).to receive(:pose_nospoof) { true }
+          expect(Scenes.custom_format("Test", @char, @enactor, true)).to eq "%xc%% scenes.emit_nospoof_from%xn%RTest"
         end
         
         it "should not include nospoof if not an emit" do
-          @char.stub(:pose_nospoof) { true }
-          Scenes.custom_format("Test", @char, @enactor, false).should eq "Test"
+          allow(@char).to receive(:pose_nospoof) { true }
+          expect(Scenes.custom_format("Test", @char, @enactor, false)).to eq "Test"
         end
       end
     end

--- a/spec/client/client_factory_specs.rb
+++ b/spec/client/client_factory_specs.rb
@@ -9,26 +9,26 @@ module AresMUSH
     before do
       @factory = ClientFactory.new
       @connection = double.as_null_object
-      Resolv.stub(:getname) { "fakehost" }
+      allow(Resolv).to receive(:getname) { "fakehost" }
     end
       
     it "should initialize and return a client" do
       client = double
-      Client.should_receive(:new).with(1, @connection) { client }
-      @factory.create_client(@connection).should eq client
+      expect(Client).to receive(:new).with(1, @connection) { client }
+      expect(@factory.create_client(@connection)).to eq client
     end
     
     it "should create clients with incremental ids" do
       client1 = @factory.create_client(@connection)
       client2 = @factory.create_client(@connection)
-      client1.id.should eq 1
-      client2.id.should eq 2
+      expect(client1.id).to eq 1
+      expect(client2.id).to eq 2
     end 
 
     it "should tell the connection what its client is" do
       client = double
-      Client.stub(:new) { client }
-      @connection.should_receive(:connect_client).with(client)
+      allow(Client).to receive(:new) { client }
+      expect(@connection).to receive(:connect_client).with(client)
       @factory.create_client(@connection)
     end
 

--- a/spec/client/client_greeter_specs.rb
+++ b/spec/client/client_greeter_specs.rb
@@ -8,8 +8,8 @@ module AresMUSH
 
     before do
       @client = double.as_null_object
-      SpecHelpers.stub_translate_for_testing
-      File.stub(:read)      
+      stub_translate_for_testing
+      allow(File).to receive(:read)      
     end
 
     describe :connected do
@@ -18,12 +18,12 @@ module AresMUSH
       end
 
       it "should send the welcome screen" do
-        File.should_receive(:read).with("game/text/connect.txt", :encoding => "UTF-8") { "Ascii Art" }
-        @client.should_receive(:emit).with("Ascii Art")
+        expect(File).to receive(:read).with("game/text/connect.txt", :encoding => "UTF-8") { "Ascii Art" }
+        expect(@client).to receive(:emit).with("Ascii Art")
       end
 
       it "should send the ares welcome text" do
-        @client.should_receive(:emit_ooc).with("client.welcome")
+        expect(@client).to receive(:emit_ooc).with("client.welcome")
       end
 
     end

--- a/spec/client/client_monitor_specs.rb
+++ b/spec/client/client_monitor_specs.rb
@@ -22,8 +22,8 @@ module AresMUSH
     
     describe :emit_all do
       it "should notify all the clients matching the specified trigger block" do
-        @client1.should_not_receive(:emit)
-        @client2.should_receive(:emit).with("Hi")
+        expect(@client1).to_not receive(:emit)
+        expect(@client2).to receive(:emit).with("Hi")
         @client_monitor.emit_all "Hi" do |c|
           c == @client2
         end
@@ -32,8 +32,8 @@ module AresMUSH
     
     describe :emit_all_ooc do
       it "should emit ooc to all the clients matching the specified trigger block" do
-        @client1.should_receive(:emit_ooc).with("Hi")
-        @client2.should_not_receive(:emit_ooc)
+        expect(@client1).to receive(:emit_ooc).with("Hi")
+        expect(@client2).to_not receive(:emit_ooc)
         @client_monitor.emit_all_ooc "Hi" do |c|
           c == @client1
         end
@@ -46,14 +46,14 @@ module AresMUSH
       end
       
       it "should emit ooc if logged in" do
-        @client_monitor.stub(:find_client).with(@char) { @client1 }
-        @client1.should_receive(:emit_ooc).with("Hi")
+        allow(@client_monitor).to receive(:find_client).with(@char) { @client1 }
+        expect(@client1).to receive(:emit_ooc).with("Hi")
         @client_monitor.emit_ooc_if_logged_in(@char, "Hi")
       end
       
       it "should not emit if not logged in" do
-        @client_monitor.stub(:find_client).with(@char) { nil }
-        @client1.should_not_receive(:emit_ooc)
+        allow(@client_monitor).to receive(:find_client).with(@char) { nil }
+        expect(@client1).to_not receive(:emit_ooc)
         @client_monitor.emit_ooc_if_logged_in(@char, "Hi")
       end
     end
@@ -65,43 +65,43 @@ module AresMUSH
       end
       
       it "should emit if logged in" do
-        @client_monitor.stub(:find_client).with(@char) { @client1 }
-        @client1.should_receive(:emit).with("Hi")
+        allow(@client_monitor).to receive(:find_client).with(@char) { @client1 }
+        expect(@client1).to receive(:emit).with("Hi")
         @client_monitor.emit_if_logged_in(@char, "Hi")
       end
       
       it "should not emit if not logged in" do
-        @client_monitor.stub(:find_client).with(@char) { nil }
-        @client1.should_not_receive(:emit)
+        allow(@client_monitor).to receive(:find_client).with(@char) { nil }
+        expect(@client1).to_not receive(:emit)
         @client_monitor.emit_if_logged_in(@char, "Hi")
       end
     end
 
     describe :connection_closed do
       it "should remove the client from the list" do
-        dispatcher.stub(:queue_event)
+        allow(dispatcher).to receive(:queue_event)
         @client_monitor.connection_closed(@client1)
-        @client_monitor.clients.should eq [@client2]
+        expect(@client_monitor.clients).to eq [@client2]
       end
       
       it "should notify the dispatcher of an anonymous client disconnected" do
-        @client1.stub(:logged_in?) { false }
-        dispatcher.should_receive(:queue_event) do |event|
-          event.class.should eq ConnectionClosedEvent
-          event.client.should eq @client1
+        allow(@client1).to receive(:logged_in?) { false }
+        expect(dispatcher).to receive(:queue_event) do |event|
+          expect(event.class).to eq ConnectionClosedEvent
+          expect(event.client).to eq @client1
         end
         @client_monitor.connection_closed(@client1)
       end
 
       it "should notify the dispatcher of a client disconnected with a char logged in" do
-        @client1.stub(:logged_in?) { true }
-        dispatcher.should_receive(:queue_event) do |event|
-          event.class.should eq ConnectionClosedEvent
-          event.client.should eq @client1
+        allow(@client1).to receive(:logged_in?) { true }
+        expect(dispatcher).to receive(:queue_event) do |event|
+          expect(event.class).to eq ConnectionClosedEvent
+          expect(event.client).to eq @client1
         end
-        dispatcher.should_receive(:queue_event) do |event|
-          event.class.should eq CharDisconnectedEvent
-          event.client.should eq @client1
+        expect(dispatcher).to receive(:queue_event) do |event|
+          expect(event.class).to eq CharDisconnectedEvent
+          expect(event.client).to eq @client1
         end
         @client_monitor.connection_closed(@client1)
       end
@@ -114,29 +114,29 @@ module AresMUSH
       end
 
       it "should create a client" do
-        @factory.should_receive(:create_client).with(@connection) { @client3 }
+        expect(@factory).to receive(:create_client).with(@connection) { @client3 }
         @client_monitor.connection_established(@connection)
       end
 
       it "should add the client to the list" do
-        @factory.stub(:create_client) { @client3 }
+        allow(@factory).to receive(:create_client) { @client3 }
         @client_monitor.connection_established(@connection)
-        @client_monitor.clients.should include @client3
+        expect(@client_monitor.clients).to include @client3
       end
 
       it "should tell the client it has connected" do
-        @factory.stub(:create_client) { @client3 }
-        @client3.should_receive(:connected)
+        allow(@factory).to receive(:create_client) { @client3 }
+        expect(@client3).to receive(:connected)
         @client_monitor.connection_established(@connection)
       end
       
       it "should notify the dispatcher" do
-        @factory.stub(:create_client) { @client3 }
-        dispatcher.should_receive(:queue_event) do |event|
-          event.class.should eq ConnectionEstablishedEvent
-          event.client.should eq @client3
+        allow(@factory).to receive(:create_client) { @client3 }
+        expect(dispatcher).to receive(:queue_event) do |event|
+          expect(event.class).to eq ConnectionEstablishedEvent
+          expect(event.client).to eq @client3
         end
-        Global.logger.should_not_receive(:debug)
+        expect(Global.logger).to_not receive(:debug)
         @client_monitor.connection_established(@connection)
       end
     end
@@ -144,27 +144,27 @@ module AresMUSH
     describe :logged_in_clients do
       it "should count logged in people" do
         client3 = double
-        @client1.stub(:logged_in?) { false }
-        @client2.stub(:logged_in?) { true }
-        client3.stub(:logged_in?) { true }
+        allow(@client1).to receive(:logged_in?) { false }
+        allow(@client2).to receive(:logged_in?) { true }
+        allow(client3).to receive(:logged_in?) { true }
         @client_monitor.clients << client3
-        @client_monitor.logged_in_clients.should eq [@client2, client3]
+        expect(@client_monitor.logged_in_clients).to eq [@client2, client3]
       end
     end
     
     describe :find_client do
       it "should find a client with a matching character" do
         char = double
-        char.stub(:id) { 123 }
-        @client1.stub(:char_id) { 123 }
-        @client_monitor.find_client(char).should eq @client1
+        allow(char).to receive(:id) { 123 }
+        allow(@client1).to receive(:char_id) { 123 }
+        expect(@client_monitor.find_client(char)).to eq @client1
       end
       
       it "should return nil if no client found" do
         char = double
-        char.stub(:id) { 123 }
-        @client1.stub(:char_id) { 456 }
-        @client_monitor.find_client(char).should eq nil
+        allow(char).to receive(:id) { 123 }
+        allow(@client1).to receive(:char_id) { 456 }
+        expect(@client_monitor.find_client(char)).to eq nil
       end
     end
   end

--- a/spec/commands/arg_parser_common_specs.rb
+++ b/spec/commands/arg_parser_common_specs.rb
@@ -8,121 +8,121 @@ module AresMUSH
     describe "arg1_slash_arg2" do
       it "should crack a matching command" do
         args = ArgParser.parse(ArgParser.arg1_slash_arg2, "a/b")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
       end
       
       it "should set values to nil if not matched" do
         args = ArgParser.parse(ArgParser.arg1_slash_arg2, "a b")
-        args.arg1.should be_nil
-        args.arg2.should be_nil
+        expect(args.arg1).to be_nil
+        expect(args.arg2).to be_nil
       end
     end
     
     describe "arg1_equals_arg2" do
       it "should crack a matching command" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2, "a=b")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
       end
       
       it "should set values to nil if not matched" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2, "a b")
-        args.arg1.should be_nil
-        args.arg2.should be_nil
+        expect(args.arg1).to be_nil
+        expect(args.arg2).to be_nil
       end
     end
     
     describe "arg1_slash_optional_arg2" do
       it "should crack a matching command" do
         args = ArgParser.parse(ArgParser.arg1_slash_optional_arg2, "a/b")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
       end
       
       it "should crack a matching command with missing optional arg" do
         args = ArgParser.parse(ArgParser.arg1_slash_optional_arg2, "a")
-        args.arg1.should eq "a"
-        args.arg2.should be_nil
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to be_nil
       end
       
       it "should set values to nil if not matched" do
         args = ArgParser.parse(ArgParser.arg1_slash_optional_arg2, "a=b")
-        args.arg1.should eq "a=b"
-        args.arg2.should be_nil
+        expect(args.arg1).to eq "a=b"
+        expect(args.arg2).to be_nil
       end
     end
     
     describe "arg1_equals_optional_arg2" do
       it "should crack a matching command" do
         args = ArgParser.parse(ArgParser.arg1_equals_optional_arg2, "a=b")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
       end
       
       it "should accept only the first arg" do
         args = ArgParser.parse(ArgParser.arg1_equals_optional_arg2, "a b")
-        args.arg1.should eq "a b"
-        args.arg2.should be_nil
+        expect(args.arg1).to eq "a b"
+        expect(args.arg2).to be_nil
       end
       
       it "should set values to nil if empty" do
         args = ArgParser.parse(ArgParser.arg1_equals_optional_arg2, "")
-        args.arg1.should be_nil
-        args.arg2.should be_nil
+        expect(args.arg1).to be_nil
+        expect(args.arg2).to be_nil
       end
     end
     
     describe "arg1_equals_arg2_slash_arg3" do
       it "should crack a matching command" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2_slash_arg3, "a=b/c")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
-        args.arg3.should eq "c"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
+        expect(args.arg3).to eq "c"
       end
       
       it "should set values to nil if not matched" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2, "a b")
-        args.arg1.should be_nil
-        args.arg2.should be_nil
-        args.arg3.should be_nil
+        expect(args.arg1).to be_nil
+        expect(args.arg2).to be_nil
+        expect(args.arg3).to be_nil
       end
       
       it "should match an arg3 with equals or slashes" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2_slash_arg3, "a=b/c = d/e")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
-        args.arg3.should eq "c = d/e"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
+        expect(args.arg3).to eq "c = d/e"
       end
     end
     
     describe "arg1_equals_arg2_slash_optional_arg3" do
       it "should crack a matching command" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2_slash_optional_arg3, "a=b/c")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
-        args.arg3.should eq "c"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
+        expect(args.arg3).to eq "c"
       end
       
       it "should crack a command without the optional arg" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2_slash_optional_arg3, "a=b")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
-        args.arg3.should be_nil
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
+        expect(args.arg3).to be_nil
       end
       
       it "should set values to nil if not matched" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2_slash_optional_arg3, "a b")
-        args.arg1.should be_nil
-        args.arg2.should be_nil
-        args.arg3.should be_nil
+        expect(args.arg1).to be_nil
+        expect(args.arg2).to be_nil
+        expect(args.arg3).to be_nil
       end
       
       it "should match an arg3 with equals or slashes" do
         args = ArgParser.parse(ArgParser.arg1_equals_arg2_slash_optional_arg3, "a=b/c = d/e")
-        args.arg1.should eq "a"
-        args.arg2.should eq "b"
-        args.arg3.should eq "c = d/e"
+        expect(args.arg1).to eq "a"
+        expect(args.arg2).to eq "b"
+        expect(args.arg3).to eq "c = d/e"
       end
     end
   end

--- a/spec/commands/arg_parser_specs.rb
+++ b/spec/commands/arg_parser_specs.rb
@@ -9,15 +9,15 @@ module AresMUSH
     describe :crack do
       it "should expand the args string into a more meaningful hash" do
         args = ArgParser.parse(/(?<a>.+)=(?<b>.+)\+(?<c>.+)/, "bar=baz+harvey")
-        args.a.should eq "bar"
-        args.b.should eq "baz"
-        args.c.should eq "harvey"
+        expect(args.a).to eq "bar"
+        expect(args.b).to eq "baz"
+        expect(args.c).to eq "harvey"
       end
   
       it "should still return a hash reader it can't crack the args" do 
         args = ArgParser.parse(/(?<a>.+)\/(?<b>.+)/, "bar=baz+harvey")
-        args.a.should be_nil
-        args.b.should be_nil
+        expect(args.a).to be_nil
+        expect(args.b).to be_nil
       end
     end
   end

--- a/spec/commands/command_alias_parser_specs.rb
+++ b/spec/commands/command_alias_parser_specs.rb
@@ -6,7 +6,7 @@ module AresMUSH
   describe CommandAliasParser do
     before do
       @enactor = double
-      @enactor.stub(:room) { nil }
+      allow(@enactor).to receive(:room) { nil }
       @shortcuts =
       {
         "a" => "b", 
@@ -16,104 +16,104 @@ module AresMUSH
         "e" => "f/g",
         "m" => "n/o foo"
       }
-      @enactor.stub(:shortcuts) { {} }
-      SpecHelpers.stub_translate_for_testing
+      allow(@enactor).to receive(:shortcuts) { {} }
+      stub_translate_for_testing
     end
     
     describe :substitute_aliases do
 
       it "should substitute enactor shortcuts" do
         cmd = Command.new("foo bar")
-        @enactor.stub(:shortcuts) { { "foo" => "help" }}
+        allow(@enactor).to receive(:shortcuts) { { "foo" => "help" }}
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "help"
-        cmd.args.should eq "bar"
+        expect(cmd.root).to eq "help"
+        expect(cmd.args).to eq "bar"
       end
             
       it "should substitute roots if the root is an alias" do
         cmd = Command.new("c/foo bar")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "d"
-        cmd.switch.should eq "foo"
-        cmd.args.should eq "bar"
+        expect(cmd.root).to eq "d"
+        expect(cmd.switch).to eq "foo"
+        expect(cmd.args).to eq "bar"
       end
           
       it "should NOT substitute roots if only part of the root is an alias" do
         cmd = Command.new("cab bar")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "cab"
-        cmd.switch.should be_nil
-        cmd.args.should eq "bar"
+        expect(cmd.root).to eq "cab"
+        expect(cmd.switch).to be_nil
+        expect(cmd.args).to eq "bar"
       end
       
       it "should substitute the go command if an exit is matched and there are no args" do
         cmd = Command.new("E")
         room = double
-        room.stub(:has_exit?).with("e") { true }
-        @enactor.stub(:room) { room }
+        allow(room).to receive(:has_exit?).with("e") { true }
+        allow(@enactor).to receive(:room) { room }
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "go"
-        cmd.args.should eq "e"
-        cmd.switch.should be_nil
+        expect(cmd.root).to eq "go"
+        expect(cmd.args).to eq "e"
+        expect(cmd.switch).to be_nil
       end
       
       it "should not substitute exit names if there are other args" do
         cmd = Command.new("X foo")
         room = double
-        room.stub(:has_exit?).with("x") { true }
-        @enactor.stub(:room) { room }
+        allow(room).to receive(:has_exit?).with("x") { true }
+        allow(@enactor).to receive(:room) { room }
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "x"
-        cmd.args.should eq "foo"
-        cmd.switch.should be_nil
+        expect(cmd.root).to eq "x"
+        expect(cmd.args).to eq "foo"
+        expect(cmd.switch).to be_nil
       end
       
       it "should substitute a switch to a single command" do
         cmd = Command.new("b/d xyz")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "f"
-        cmd.switch.should be_nil
-        cmd.args.should eq "xyz"
+        expect(cmd.root).to eq "f"
+        expect(cmd.switch).to be_nil
+        expect(cmd.args).to eq "xyz"
       end
       
       it "should substitute a single command to a switch" do
         cmd = Command.new("e xyz")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "f"
-        cmd.switch.should eq "g"
-        cmd.args.should eq "xyz"
+        expect(cmd.root).to eq "f"
+        expect(cmd.switch).to eq "g"
+        expect(cmd.args).to eq "xyz"
       end
       
       it "should double substitute both a root and a switch" do
         cmd = Command.new("a/c xyz")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "d"
-        cmd.switch.should eq "e"
-        cmd.args.should eq "xyz"
+        expect(cmd.root).to eq "d"
+        expect(cmd.switch).to eq "e"
+        expect(cmd.args).to eq "xyz"
       end
           
       it "should NOT substitute a partial match on a switch" do
         cmd = Command.new("b/ccc foo")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "b"
-        cmd.switch.should eq "ccc"
-        cmd.args.should eq "foo"
+        expect(cmd.root).to eq "b"
+        expect(cmd.switch).to eq "ccc"
+        expect(cmd.args).to eq "foo"
       end
       
       it "should substitute a full commmand with args" do
         cmd = Command.new("m bar")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "n"
-        cmd.switch.should eq "o"
-        cmd.args.should eq "foo bar"
+        expect(cmd.root).to eq "n"
+        expect(cmd.switch).to eq "o"
+        expect(cmd.args).to eq "foo bar"
       end
           
       it "should substitute even with a prefix" do
         cmd = Command.new("+m bar")
         CommandAliasParser.substitute_aliases(@enactor, cmd, @shortcuts)
-        cmd.root.should eq "n"
-        cmd.switch.should eq "o"
-        cmd.args.should eq "foo bar"
+        expect(cmd.root).to eq "n"
+        expect(cmd.switch).to eq "o"
+        expect(cmd.args).to eq "foo bar"
       end
       
     end

--- a/spec/commands/command_cracker_specs.rb
+++ b/spec/commands/command_cracker_specs.rb
@@ -10,202 +10,202 @@ module AresMUSH
       
       it "should be able to crack a root-only command" do
         cracked = CommandCracker.crack("test")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq nil
-        cracked[:args].should eq nil
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq nil
       end
 
       it "should be able to crack a root that's just a number" do
         cracked = CommandCracker.crack("1")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "1"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq nil
-        cracked[:args].should eq nil
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "1"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq nil
       end
       
       it "should be able to crack a root with a page" do
         cracked = CommandCracker.crack("test1")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq nil
-        cracked[:args].should eq nil
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq nil
       end
 
       it "should be able to crack a root with a page and an arg" do
         cracked = CommandCracker.crack("test2 foo")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 2
-        cracked[:switch].should eq nil
-        cracked[:args].should eq "foo"        
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 2
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq "foo"        
       end
       
       it "should be able to crack a root followed by a space and arg" do
         cracked = CommandCracker.crack("test abc")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq nil
-        cracked[:args].should eq "abc"        
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq "abc"        
       end
 
       it "should be able to crack a root followed by a space and number" do
         cracked = CommandCracker.crack("test 2")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq nil
-        cracked[:args].should eq "2"
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq "2"
       end
 
       it "should be able to crack a root followed by a slash and switch" do
         cracked = CommandCracker.crack("test/sw")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "sw"
-        cracked[:args].should eq nil        
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "sw"
+        expect(cracked[:args]).to eq nil        
       end
       
       it "should be able to crack a root with page followed by a slash and switch" do
         cracked = CommandCracker.crack("test2/sw")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 2
-        cracked[:switch].should eq "sw"
-        cracked[:args].should eq nil        
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 2
+        expect(cracked[:switch]).to eq "sw"
+        expect(cracked[:args]).to eq nil        
       end
       
       it "should be able to crack a root with page after the switch xxx" do
         cracked = CommandCracker.crack("test/sw2")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 2
-        cracked[:switch].should eq "sw"
-        cracked[:args].should eq nil        
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 2
+        expect(cracked[:switch]).to eq "sw"
+        expect(cracked[:args]).to eq nil        
       end
 
       it "should be able to crack a root followed by a slash and switch and arg" do
         cracked = CommandCracker.crack("test/sw arg")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "sw"
-        cracked[:args].should eq "arg"        
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "sw"
+        expect(cracked[:args]).to eq "arg"        
       end
       
       it "should be able to crack a root followed by a space and switch and number" do
         cracked = CommandCracker.crack("test/sw 2")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "sw"
-        cracked[:args].should eq "2"
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "sw"
+        expect(cracked[:args]).to eq "2"
       end
 
       it "should be able to strip off crazy spaces" do
         cracked = CommandCracker.crack("   test/sw    2   ")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "sw"
-        cracked[:args].should eq "2"
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "sw"
+        expect(cracked[:args]).to eq "2"
       end
 
       it "should not recognize a switch that's spaced out" do
         cracked = CommandCracker.crack("   test  /  sw    2   ")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq nil
-        cracked[:args].should eq "/  sw    2"
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq "/  sw    2"
       end
       
     
       it "should handle a + prefix" do
         cracked = CommandCracker.crack("+test/foo bar")
-        cracked[:prefix].should eq "+"
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "foo"
-        cracked[:args].should eq "bar"
+        expect(cracked[:prefix]).to eq "+"
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "foo"
+        expect(cracked[:args]).to eq "bar"
       end  
       
       it "should handle a / prefix" do
         cracked = CommandCracker.crack("/test/foo bar")
-        cracked[:prefix].should eq "/"
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "foo"
-        cracked[:args].should eq "bar"
+        expect(cracked[:prefix]).to eq "/"
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "foo"
+        expect(cracked[:args]).to eq "bar"
       end
       
       it "should handle an @ prefix" do
         cracked = CommandCracker.crack("@test/foo bar")
-        cracked[:prefix].should eq "@"
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "foo"
-        cracked[:args].should eq "bar"
+        expect(cracked[:prefix]).to eq "@"
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "foo"
+        expect(cracked[:args]).to eq "bar"
       end
       
       it "should handle an = prefix" do
         cracked = CommandCracker.crack("=test/foo bar")
-        cracked[:prefix].should eq "="
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "foo"
-        cracked[:args].should eq "bar"
+        expect(cracked[:prefix]).to eq "="
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "foo"
+        expect(cracked[:args]).to eq "bar"
       end
 
       it "should handle an & prefix" do
         cracked = CommandCracker.crack("&test/foo bar")
-        cracked[:prefix].should eq "&"
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "foo"
-        cracked[:args].should eq "bar"
+        expect(cracked[:prefix]).to eq "&"
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "foo"
+        expect(cracked[:args]).to eq "bar"
       end
       
       it "should handle no prefix" do
         cracked = CommandCracker.crack("test/foo bar")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "foo"
-        cracked[:args].should eq "bar"
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "foo"
+        expect(cracked[:args]).to eq "bar"
       end
       
       it "should handle a weird prefix" do
         cracked = CommandCracker.crack("~test/foo bar")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq "~test"
-        cracked[:page].should eq 1
-        cracked[:switch].should eq "foo"
-        cracked[:args].should eq "bar"
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq "~test"
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq "foo"
+        expect(cracked[:args]).to eq "bar"
       end
       
       it "should be able to crack an empty string" do
         cracked = CommandCracker.crack("")
-        cracked[:prefix].should eq nil
-        cracked[:root].should eq ""
-        cracked[:page].should eq 1
-        cracked[:switch].should eq nil
-        cracked[:args].should eq nil
+        expect(cracked[:prefix]).to eq nil
+        expect(cracked[:root]).to eq ""
+        expect(cracked[:page]).to eq 1
+        expect(cracked[:switch]).to eq nil
+        expect(cracked[:args]).to eq nil
       end
     end
   
     describe :strip_prefix do
       it "should remove prefixes" do
-        CommandCracker.strip_prefix("+xyz").should eq "xyz"
-        CommandCracker.strip_prefix("@xyz").should eq "xyz"
-        CommandCracker.strip_prefix("=xyz").should eq "xyz"
-        CommandCracker.strip_prefix("&xyz").should eq "xyz"
-        CommandCracker.strip_prefix("xyz").should eq "xyz"
+        expect(CommandCracker.strip_prefix("+xyz")).to eq "xyz"
+        expect(CommandCracker.strip_prefix("@xyz")).to eq "xyz"
+        expect(CommandCracker.strip_prefix("=xyz")).to eq "xyz"
+        expect(CommandCracker.strip_prefix("&xyz")).to eq "xyz"
+        expect(CommandCracker.strip_prefix("xyz")).to eq "xyz"
       end
     end
     

--- a/spec/commands/command_specs.rb
+++ b/spec/commands/command_specs.rb
@@ -9,11 +9,11 @@ module AresMUSH
     describe :initialize do      
       it "should initialize the raw input" do
         cmd = Command.new("test/sw foo")
-        cmd.raw.should eq "test/sw foo"
+        expect(cmd.raw).to eq "test/sw foo"
       end
       
       it "should crack the command" do
-        CommandCracker.should_receive(:crack).with("test 123") { { :root => "r", :switch => "s", :args => "a" }}
+        expect(CommandCracker).to receive(:crack).with("test 123") { { :root => "r", :switch => "s", :args => "a" }}
         cmd = Command.new("test 123")        
       end
     end
@@ -22,99 +22,99 @@ module AresMUSH
      
       it "should set the root" do
         cmd = Command.new("test/sw foo")
-        cmd.root.should eq "test"
+        expect(cmd.root).to eq "test"
       end      
 
       it "should set the raw command" do
         cmd = Command.new("test/sw foo")
-        cmd.raw.should eq "test/sw foo"
+        expect(cmd.raw).to eq "test/sw foo"
       end
 
       it "should use the command ArgParser to parse the command" do
-        CommandCracker.should_receive(:crack).with("test 123") { { :root => "r", :switch => "s", :args => "a" }}
+        expect(CommandCracker).to receive(:crack).with("test 123") { { :root => "r", :switch => "s", :args => "a" }}
         cmd = Command.new("test 123")
-        cmd.root.should eq "r"
-        cmd.switch.should eq "s"
-        cmd.args.should eq "a"
+        expect(cmd.root).to eq "r"
+        expect(cmd.switch).to eq "s"
+        expect(cmd.args).to eq "a"
       end
       
       it "should save the results from ArgParser even if they're nil" do
-        CommandCracker.should_receive(:crack).with("test 123") { { :root => nil, :switch => nil, :args => nil }}
+        expect(CommandCracker).to receive(:crack).with("test 123") { { :root => nil, :switch => nil, :args => nil }}
         cmd = Command.new("test 123")
-        cmd.root.should eq nil
-        cmd.switch.should eq nil
-        cmd.args.should eq nil
+        expect(cmd.root).to eq nil
+        expect(cmd.switch).to eq nil
+        expect(cmd.args).to eq nil
       end
     end
 
     describe :parse_args do
       it "should parse the args" do
         regex = /.+/
-        ArgParser.should_receive(:parse).with(regex, "123") { HashReader.new({ :a => "a" }) }
+        expect(ArgParser).to receive(:parse).with(regex, "123") { HashReader.new({ :a => "a" }) }
         cmd = Command.new("test 123")
         args = cmd.parse_args(regex)
-        args.a.should eq "a"
+        expect(args.a).to eq "a"
       end
     end
     
     describe :root_is? do      
       it "should match the specified root" do
         cmd = Command.new("test/foo bar")
-        cmd.root_is?("test").should be true
+        expect(cmd.root_is?("test")).to be true
       end
 
       it "should not match a different root" do
         cmd = Command.new("test/foo bar")
-        cmd.root_is?("foo").should be false
+        expect(cmd.root_is?("foo")).to be false
       end
       
       it "should ignore case in the root" do
         cmd = Command.new("TesT/foo bar")
-        cmd.root_is?("test").should be true
+        expect(cmd.root_is?("test")).to be true
       end            
     end
     
     describe :switch_is? do      
       it "should match the specified switch" do
         cmd = Command.new("test/foo bar")
-        cmd.switch_is?("foo").should be true
+        expect(cmd.switch_is?("foo")).to be true
       end
 
       it "should not match a different switch" do
         cmd = Command.new("test/foo bar")
-        cmd.switch_is?("bar").should be false
+        expect(cmd.switch_is?("bar")).to be false
       end
       
       it "should ignore case in the switch" do
         cmd = Command.new("test/fOO bar")
-        cmd.switch_is?("foo").should be true
+        expect(cmd.switch_is?("foo")).to be true
       end      
       
       it "should return false for a nil root" do
         cmd = Command.new("test bar")
-        cmd.switch_is?("foo").should be false
+        expect(cmd.switch_is?("foo")).to be false
       end
     end
     
     describe :root_only? do
       it "should return true if there's no switch and no args" do
         cmd = Command.new("test")
-        cmd.root_only?.should be true
+        expect(cmd.root_only?).to be true
       end
       
       it "should return false if there's a switch" do
         cmd = Command.new("test/foo")
-        cmd.root_only?.should be false
+        expect(cmd.root_only?).to be false
       end
 
       it "should return false if there's an arg" do
         cmd = Command.new("test foo")
-        cmd.root_only?.should be false
+        expect(cmd.root_only?).to be false
       end
       
       it "should return false if there's both a switch and arg" do
         cmd = Command.new("test/foo bar")
-        cmd.root_only?.should be false
+        expect(cmd.root_only?).to be false
       end        
     end
   end

--- a/spec/commands/dispatcher_specs.rb
+++ b/spec/commands/dispatcher_specs.rb
@@ -14,85 +14,85 @@ module AresMUSH
       stub_global_objects
       @enactor = double
       @client = double
-      @client.stub(:id) { "1" }
-      @client.stub(:room) { nil }
-      @client.stub(:char) { @enactor }
+      allow(@client).to receive(:id) { "1" }
+      allow(@client).to receive(:room) { nil }
+      allow(@client).to receive(:char) { @enactor }
       @command = Command.new("x")
       @dispatcher = Dispatcher.new
       @plugin1 = double
       @plugin2 = double
-      @plugin1.stub(:log_command)
-      @plugin2.stub(:log_command)
+      allow(@plugin1).to receive(:log_command)
+      allow(@plugin2).to receive(:log_command)
       @shortcuts = {}
-      @client.stub(:emit_ooc)
-      @enactor.stub(:is_statue?) { false }
-      plugin_manager.stub(:shortcuts) { @shortcuts }
-      CommandAliasParser.stub(:substitute_aliases)
-      SpecHelpers.stub_translate_for_testing
+      allow(@client).to receive(:emit_ooc)
+      allow(@enactor).to receive(:is_statue?) { false }
+      allow(plugin_manager).to receive(:shortcuts) { @shortcuts }
+      allow(CommandAliasParser).to receive(:substitute_aliases)
+      stub_translate_for_testing
     end
 
     describe :on_command do
       context "No Errors" do
         before do 
-          Global.logger.stub(:error) do |msg| 
+          allow(Global.logger).to receive(:error) do |msg| 
             raise msg
           end
           @handler = double
           @handler_class = double
-          plugin_manager.stub(:plugins) { [] }
+          allow(plugin_manager).to receive(:plugins) { [] }
         end
         
         it "performs alias substitutions" do
-          CommandAliasParser.should_receive(:substitute_aliases).with(@enactor, @command, @shortcuts)
+          expect(CommandAliasParser).to receive(:substitute_aliases).with(@enactor, @command, @shortcuts)
           @dispatcher.on_command(@client, @command)
         end
       
         it "should look up the enactor" do
-          @client.should_receive(:char) { @enactor }
+          expect(@client).to receive(:char) { @enactor }
           @dispatcher.on_command(@client, @command)
         end
         
         it "should do nothing if enactor is a statue" do
-          @enactor.should_receive(:is_statue?) { true }
-          @client.should_receive(:emit_failure).with("dispatcher.you_are_statue")
+          expect(@enactor).to receive(:is_statue?) { true }
+          expect(@client).to receive(:emit_failure).with("dispatcher.you_are_statue")
           @dispatcher.on_command(@client, @command)
         end
         
         it "gets the list of plugins from the plugin manager" do
-          plugin_manager.should_receive(:plugins) { [] }
+          expect(plugin_manager).to receive(:plugins) { [] }
           @dispatcher.on_command(@client, @command)
         end
       
         it "asks each plugin if it wants a command" do
-          plugin_manager.stub(:plugins) { [ @plugin1, @plugin2 ] }
-          @plugin1.should_receive(:get_cmd_handler).with(@client, @command, @enactor) { false }
-          @plugin2.should_receive(:get_cmd_handler).with(@client, @command, @enactor) { false }
+          allow(plugin_manager).to receive(:plugins) { [ @plugin1, @plugin2 ] }
+          expect(@plugin1).to receive(:get_cmd_handler).with(@client, @command, @enactor) { false }
+          expect(@plugin2).to receive(:get_cmd_handler).with(@client, @command, @enactor) { false }
           @dispatcher.on_command(@client, @command)
         end      
             
         it "stops after finding one plugin to handle the command" do
-          plugin_manager.stub(:plugins) { [ @plugin1, @plugin2 ] }
-          @handler_class.stub(:new).with(@client, @command, @enactor) { @handler }
-          @handler.should_receive(:on_command)
-          @plugin1.should_receive(:get_cmd_handler).with(@client, @command, @enactor) { @handler_class }
-          @plugin2.should_not_receive(:get_cmd_handler)
+          allow(plugin_manager).to receive(:plugins) { [ @plugin1, @plugin2 ] }
+          allow(@handler_class).to receive(:new).with(@client, @command, @enactor) { @handler }
+          expect(@handler).to receive(:on_command)
+          expect(@plugin1).to receive(:get_cmd_handler).with(@client, @command, @enactor) { @handler_class }
+          expect(@plugin2).to_not receive(:get_cmd_handler)
           @dispatcher.on_command(@client, @command)
         end
       
         it "continues processing if the first plugin doesn't want the command" do
-          plugin_manager.stub(:plugins) { [ @plugin1, @plugin2 ] }
-          @handler_class.stub(:new).with(@client, @command, @enactor) { @handler }
-          @handler.should_receive(:on_command)
-          @plugin1.should_receive(:get_cmd_handler).with(@client, @command, @enactor) { nil }
-          @plugin2.should_receive(:get_cmd_handler).with(@client, @command, @enactor) { @handler_class }
+          allow(plugin_manager).to receive(:plugins) { [ @plugin1, @plugin2 ] }
+          allow(@handler_class).to receive(:new).with(@client, @command, @enactor) { @handler }
+          expect(@handler).to receive(:on_command)
+          expect(@plugin1).to receive(:get_cmd_handler).with(@client, @command, @enactor) { nil }
+          expect(@plugin2).to receive(:get_cmd_handler).with(@client, @command, @enactor) { @handler_class }
           @dispatcher.on_command(@client, @command)
         end
 
         it "sends huh message if nobody handles the command" do
-          plugin_manager.stub(:plugins) { [ @plugin1, @plugin2 ] }
-          @plugin1.should_receive(:get_cmd_handler).with(@client, @command, @enactor) { nil }
-          @plugin2.should_receive(:get_cmd_handler).with(@client, @command, @enactor) { nil }
-          @client.should_receive(:emit_ooc).with("dispatcher.huh")
+          allow(plugin_manager).to receive(:plugins) { [ @plugin1, @plugin2 ] }
+          expect(@plugin1).to receive(:get_cmd_handler).with(@client, @command, @enactor) { nil }
+          expect(@plugin2).to receive(:get_cmd_handler).with(@client, @command, @enactor) { nil }
+          expect(@client).to receive(:emit_ooc).with("dispatcher.huh")
           @dispatcher.on_command(@client, @command)
         end      
       end
@@ -100,28 +100,28 @@ module AresMUSH
       context "Errors" do
         
         before do
-          @dispatcher.stub(:queue_event) { }
+          allow(@dispatcher).to receive(:queue_event) { }
         end
       
         it "keeps asking plugins if they want the command after an error" do
-          plugin_manager.stub(:plugins) { [ @plugin1, @plugin2 ] }
-          @plugin1.should_receive(:get_cmd_handler).and_raise("an error")
-          @plugin2.should_receive(:get_cmd_handler).with(@client, @command, @enactor)
+          allow(plugin_manager).to receive(:plugins) { [ @plugin1, @plugin2 ] }
+          expect(@plugin1).to receive(:get_cmd_handler).and_raise("an error")
+          expect(@plugin2).to receive(:get_cmd_handler).with(@client, @command, @enactor)
           @dispatcher.on_command(@client, @command)
         end
         
         it "catches exceptions from within the command handling" do
-          plugin_manager.stub(:plugins) { [ @plugin1 ] }
-          @plugin1.stub(:get_cmd_handler).and_raise("an error")
-          @command.stub(:raw) { "raw" }
-          @client.should_receive(:emit_failure).with("dispatcher.unexpected_error")
+          allow(plugin_manager).to receive(:plugins) { [ @plugin1 ] }
+          allow(@plugin1).to receive(:get_cmd_handler).and_raise("an error")
+          allow(@command).to receive(:raw) { "raw" }
+          expect(@client).to receive(:emit_failure).with("dispatcher.unexpected_error")
           @dispatcher.on_command(@client, @command)
         end
       
         it "allows a plugin exit exception to bubble up" do
-          plugin_manager.stub(:plugins) { [ @plugin1 ] }
-          @plugin1.stub(:get_cmd_handler) { true }
-          @plugin1.stub(:get_cmd_handler).and_raise(SystemExit)
+          allow(plugin_manager).to receive(:plugins) { [ @plugin1 ] }
+          allow(@plugin1).to receive(:get_cmd_handler) { true }
+          allow(@plugin1).to receive(:get_cmd_handler).and_raise(SystemExit)
           expect {@dispatcher.on_command(@client, @command)}.to raise_error(SystemExit)
         end
       end
@@ -129,37 +129,37 @@ module AresMUSH
 
     describe :on_event do
       before do
-        dispatcher.stub(:spawn).and_yield
+        allow(dispatcher).to receive(:spawn).and_yield
       end
       
       it "should send the event to any class that handles it" do
         plugin1 = double
         plugin2 = double
-        plugin_manager.stub(:plugins) { [ plugin1, plugin2 ] }
+        allow(plugin_manager).to receive(:plugins) { [ plugin1, plugin2 ] }
         event = double
         handler_class = double
         handler1 = double
         handler2 = double
-        handler_class.should_receive(:new) { handler1 }
-        handler_class.should_receive(:new) { handler2 }
-        plugin1.should_receive(:get_event_handler).with(event.class.to_s) { handler_class }
-        plugin2.should_receive(:get_event_handler).with(event.class.to_s) { handler_class }
-        handler1.should_receive(:on_event).with(event)
-        handler2.should_receive(:on_event).with(event)
+        expect(handler_class).to receive(:new) { handler1 }
+        expect(handler_class).to receive(:new) { handler2 }
+        expect(plugin1).to receive(:get_event_handler).with(event.class.to_s) { handler_class }
+        expect(plugin2).to receive(:get_event_handler).with(event.class.to_s) { handler_class }
+        expect(handler1).to receive(:on_event).with(event)
+        expect(handler2).to receive(:on_event).with(event)
         @dispatcher.on_event event
       end
       
       it "should not send event to a class that doesn't want it" do
         plugin1 = double
         plugin2 = double
-        plugin_manager.stub(:plugins) { [ plugin1, plugin2 ] }
+        allow(plugin_manager).to receive(:plugins) { [ plugin1, plugin2 ] }
         event = double
         handler_class = double
         handler = double
-        handler_class.should_receive(:new) { handler }
-        plugin1.should_receive(:get_event_handler).with(event.class.to_s) { nil }
-        plugin2.should_receive(:get_event_handler).with(event.class.to_s) { handler_class }
-        handler.should_receive(:on_event).with(event)
+        expect(handler_class).to receive(:new) { handler }
+        expect(plugin1).to receive(:get_event_handler).with(event.class.to_s) { nil }
+        expect(plugin2).to receive(:get_event_handler).with(event.class.to_s) { handler_class }
+        expect(handler).to receive(:on_event).with(event)
         @dispatcher.on_event event
       end
       

--- a/spec/config/config_reader_specs.rb
+++ b/spec/config/config_reader_specs.rb
@@ -8,16 +8,16 @@ module AresMUSH
 
     describe :config_path do 
       it "should be the game dir plus the config dir" do
-        AresMUSH.stub(:game_path) { "game" }
-        ConfigReader.config_path.should eq File.join("game", "config")
+        allow(AresMUSH).to receive(:game_path) { "game" }
+        expect(ConfigReader.config_path).to eq File.join("game", "config")
       end
     end
 
     describe :config_files do 
       it "searches for files in the config dir" do
-        AresMUSH.stub(:game_path) { "game" }
-        Dir.should_receive(:[]).with(File.join("game", "config", "**", "*.yml")) { ["a", "b"]}
-        ConfigReader.config_files.should eq ["a", "b"]
+        allow(AresMUSH).to receive(:game_path) { "game" }
+        expect(Dir).to receive(:[]).with(File.join("game", "config", "**", "*.yml")) { ["a", "b"]}
+        expect(ConfigReader.config_files).to eq ["a", "b"]
       end
     end
     
@@ -29,51 +29,51 @@ module AresMUSH
       
       it "should return the section if specified" do
         hash = { "b" => "c" }
-        @config_reader.get_config("a").should eq hash 
+        expect(@config_reader.get_config("a")).to eq hash 
       end
       
       it "should return the subsection if specified and the section exists" do
-        @config_reader.get_config("a", "b").should eq "c"
+        expect(@config_reader.get_config("a", "b")).to eq "c"
       end
       
       it "should return nil if the section for the requested subsection doesn't exist" do
-        @config_reader.get_config("d", "e").should be_nil
+        expect(@config_reader.get_config("d", "e")).to be_nil
       end
       
       it "should return sub-subsection if it exists" do
-        @config_reader.get_config("e", "f", "g"). should eq "h"
+        expect(@config_reader.get_config("e", "f", "g")).to eq "h"
       end
       
       it "should return nil if the sub-subsection doesn't exist" do
-        @config_reader.get_config("e", "f", "i"). should be_nil 
+        expect(@config_reader.get_config("e", "f", "i")).to be_nil 
       end
     end
 
     describe :load_game_config do 
       before do
         @reader = ConfigReader.new
-        ConfigReader.stub(:config_files) { ["a", "b"] }
+        allow(ConfigReader).to receive(:config_files) { ["a", "b"] }
       end
       
       it "should read the game config" do        
         config = double
-        @reader.stub(:config) { config }
+        allow(@reader).to receive(:config) { config }
         
-        @reader.stub(:validate_config_file).with("a") { true }
-        @reader.stub(:validate_config_file).with("b") { true }
-        config.should_receive(:merge_yaml).with("a")
-        config.should_receive(:merge_yaml).with("b")
+        allow(@reader).to receive(:validate_config_file).with("a") { true }
+        allow(@reader).to receive(:validate_config_file).with("b") { true }
+        expect(config).to receive(:merge_yaml).with("a")
+        expect(config).to receive(:merge_yaml).with("b")
         @reader.load_game_config 
       end 
       
       it "should not read a game config file that has an error" do        
         config = double
-        @reader.stub(:config) { config }
+        allow(@reader).to receive(:config) { config }
         
-        @reader.stub(:validate_config_file).with("a") { true }
-        @reader.stub(:validate_config_file).with("b").and_raise("error")
-        config.should_receive(:merge_yaml).with("a")
-        config.should_not_receive(:merge_yaml).with("b")
+        allow(@reader).to receive(:validate_config_file).with("a") { true }
+        allow(@reader).to receive(:validate_config_file).with("b").and_raise("error")
+        expect(config).to receive(:merge_yaml).with("a")
+        expect(config).to_not receive(:merge_yaml).with("b")
         @reader.load_game_config 
       end  
     end
@@ -81,16 +81,16 @@ module AresMUSH
     describe :validate_game_config do 
       before do
         @reader = ConfigReader.new
-        ConfigReader.stub(:config_files) { ["a", "b"] }
+        allow(ConfigReader).to receive(:config_files) { ["a", "b"] }
       end
       
       
       it "should check the config" do        
         config = double
-        @reader.stub(:config) { config }
+        allow(@reader).to receive(:config) { config }
 
-        AresMUSH::YamlExtensions.should_receive(:yaml_hash).with("a").and_raise("error")
-        AresMUSH::YamlExtensions.should_not_receive(:yaml_hash).with("a")
+        expect(AresMUSH::YamlExtensions).to receive(:yaml_hash).with("a").and_raise("error")
+        expect(AresMUSH::YamlExtensions).to_not receive(:yaml_hash).with("a")
         expect { @reader.validate_game_config }.to raise_error(RuntimeError)
       end          
     end

--- a/spec/config/help_reader_specs.rb
+++ b/spec/config/help_reader_specs.rb
@@ -9,39 +9,39 @@ module AresMUSH
     before do
       @markdown = double
       @help_data = { "toc" => "c", "aliases" => [ "x" ] }
-      @markdown.stub(:metadata) { @help_data } 
-      @markdown.stub(:contents) { "contents" }
-      @markdown.stub(:load_file)
-      MarkdownFile.stub(:new) { @markdown }
+      allow(@markdown).to receive(:metadata) { @help_data } 
+      allow(@markdown).to receive(:contents) { "contents" }
+      allow(@markdown).to receive(:load_file)
+      allow(MarkdownFile).to receive(:new) { @markdown }
       @reader = HelpReader.new     
     end
     
     describe :load_help_file do 
       it "should load the metadata" do
-        MarkdownFile.should_receive(:new).with("file") { @markdown }
+        expect(MarkdownFile).to receive(:new).with("file") { @markdown }
         @reader.load_help_file("file", "Plugin")
-        @reader.help_file_index["file"]["toc"].should eq "c"
+        expect(@reader.help_file_index["file"]["toc"]).to eq "c"
       end
       
       it "should set the plugin and path" do
-        MarkdownFile.stub(:new).with("file") { @markdown }
+        allow(MarkdownFile).to receive(:new).with("file") { @markdown }
         @reader.load_help_file("file", "Plugin")
-        @reader.help_file_index["file"]["path"].should eq "file"
-        @reader.help_file_index["file"]["plugin"].should eq "plugin"
+        expect(@reader.help_file_index["file"]["path"]).to eq "file"
+        expect(@reader.help_file_index["file"]["plugin"]).to eq "plugin"
       end
       
       it "should set the toc" do
-        MarkdownFile.should_receive(:new).with("file") { @markdown }
+        expect(MarkdownFile).to receive(:new).with("file") { @markdown }
         @reader.load_help_file("file", "Plugin")
-        @reader.help_toc["c"].should eq [ "file" ]
+        expect(@reader.help_toc["c"]).to eq [ "file" ]
       end
       
       it "should set the keys" do
-        MarkdownFile.should_receive(:new).with("file") { @markdown }
+        expect(MarkdownFile).to receive(:new).with("file") { @markdown }
         @reader.load_help_file("file", "Plugin")
-        @reader.help_keys["x"].should eq "file"
-        @reader.help_keys["file"].should eq "file"
-        @reader.help_keys["files"].should eq "file"
+        expect(@reader.help_keys["x"]).to eq "file"
+        expect(@reader.help_keys["file"]).to eq "file"
+        expect(@reader.help_keys["files"]).to eq "file"
       end
     end
     
@@ -53,8 +53,8 @@ module AresMUSH
         @reader.help_file_index["b"] = yhelp
         
         @reader.unload_help("x")
-        @reader.help_file_index["a"].should be_nil
-        @reader.help_file_index["b"].should eq yhelp
+        expect(@reader.help_file_index["a"]).to be_nil
+        expect(@reader.help_file_index["b"]).to eq yhelp
       end
       
     end

--- a/spec/connection_specs.rb
+++ b/spec/connection_specs.rb
@@ -12,15 +12,15 @@ module AresMUSH
       
     describe :ping do
       it "should send an empty string" do
-        @connection.should_receive(:send_data).with("\e[0m")
+        expect(@connection).to receive(:send_data).with("\e[0m")
         @connection.ping
       end
     end
     
     describe :send_formatted do
       it "should format the message before sending" do
-        MushFormatter.should_receive(:format).with("test", true) { "TEST" }
-        @connection.should_receive(:send_data).with("TEST")
+        expect(MushFormatter).to receive(:format).with("test", true) { "TEST" }
+        expect(@connection).to receive(:send_data).with("TEST")
         @connection.send_formatted("test")
       end
     end    
@@ -28,39 +28,39 @@ module AresMUSH
     describe :receive_data do
       before do
         @client = double
-        @client.stub(:id) { 1 }
+        allow(@client).to receive(:id) { 1 }
         @connection.connect_client @client
         negotiator = double
         @connection.negotiator = negotiator
-        negotiator.stub(:handle_input) do |data|
+        allow(negotiator).to receive(:handle_input) do |data|
           data
         end
       end
       
       it "should send data to the client" do
-        @client.should_receive(:handle_input).with("test\n")
+        expect(@client).to receive(:handle_input).with("test\n")
         @connection.receive_data("test\n")        
       end
       
       it "should strip null control codes" do
-        @client.should_receive(:handle_input).with("test\n")
+        expect(@client).to receive(:handle_input).with("test\n")
         @connection.receive_data("test^@\0\n")
       end
       
       it "should handle multiple commands" do
-        @client.should_receive(:handle_input).with("test1\n")
-        @client.should_receive(:handle_input).with("test2\n")
+        expect(@client).to receive(:handle_input).with("test1\n")
+        expect(@client).to receive(:handle_input).with("test2\n")
         @connection.receive_data("test1\ntest2\n")
       end
       
       it "should accumulate partial commands" do
-        @client.should_receive(:handle_input).with("test\n")
+        expect(@client).to receive(:handle_input).with("test\n")
         @connection.receive_data("te")
         @connection.receive_data("st\n")
       end
       
       it "should convert control code newline to newline" do
-        @client.should_receive(:handle_input).with("test\nfoo\n")
+        expect(@client).to receive(:handle_input).with("test\nfoo\n")
         @connection.receive_data("test^Mfoo\n")    
       end
     end
@@ -68,9 +68,9 @@ module AresMUSH
     describe :unbind do
       it "should notify the client that it disconnected" do
         client = double
-        client.stub(:id) { 1 }
+        allow(client).to receive(:id) { 1 }
         @connection.connect_client client
-        client.should_receive(:connection_closed)
+        expect(client).to receive(:connection_closed)
         @connection.unbind
       end
     end

--- a/spec/core_ext/hash_ext_specs.rb
+++ b/spec/core_ext/hash_ext_specs.rb
@@ -12,8 +12,8 @@ module AresMUSH
         h2 = { 'a' => { 'd' => "Hi there!" }}
         
         merge = h.merge_recursively(h2)
-        merge['a'].should include('b' => 9999, 'c' => "Test")
-        merge.should include('z' => 1)
+        expect(merge['a']).to include('b' => 9999, 'c' => "Test")
+        expect(merge).to include('z' => 1)
       end
     end
     
@@ -23,47 +23,47 @@ module AresMUSH
         h2 = { 'a' => { 'd' => "Hi there!" }}
         
         h.merge_recursively!(h2)
-        h['a'].should include('b' => 9999, 'c' => "Test")
-        h.should include('z' => 1)
+        expect(h['a']).to include('b' => 9999, 'c' => "Test")
+        expect(h).to include('z' => 1)
       end
     end
     
     describe :has_insensitive_key? do
       it "should match a key" do
         h = { 'a' => "D" }
-        h.has_insensitive_key?("A").should be true
-        h.has_insensitive_key?("a").should be true
+        expect(h.has_insensitive_key?("A")).to be true
+        expect(h.has_insensitive_key?("a")).to be true
       end
       
       it "should not match a missing key" do
         h = { 'a' => "D" }
-        h.has_insensitive_key?("x").should be false
+        expect(h.has_insensitive_key?("x")).to be false
       end     
     end
     
     describe :get_insensitive_key do
       it "should get a key" do
         h = { 'a' => "D" }
-        h.get_insensitive_key("A").should eq "a"
-        h.get_insensitive_key("a").should eq "a"
+        expect(h.get_insensitive_key("A")).to eq "a"
+        expect(h.get_insensitive_key("a")).to eq "a"
       end
       
       it "should not get a missing key" do
         h = { 'a' => "D" }
-        h.get_insensitive_key("x").should be_nil
+        expect(h.get_insensitive_key("x")).to be_nil
       end     
     end
     
     describe :get_insensitive_value do
       it "should get a key" do
         h = { 'a' => "D" }
-        h.get_insensitive_value("A").should eq "D"
-        h.get_insensitive_value("a").should eq "D"
+        expect(h.get_insensitive_value("A")).to eq "D"
+        expect(h.get_insensitive_value("a")).to eq "D"
       end
       
       it "should not get a missing key" do
         h = { 'a' => "D" }
-        h.get_insensitive_value("x").should be_nil
+        expect(h.get_insensitive_value("x")).to be_nil
       end     
     end
     
@@ -74,13 +74,13 @@ module AresMUSH
       end
       
       it "should read in the yaml file" do
-        YamlExtensions.should_receive(:yaml_hash).with("file.yml") { @yaml }
+        expect(YamlExtensions).to receive(:yaml_hash).with("file.yml") { @yaml }
         @h.merge_yaml("file.yml")
       end
 
       it "should merge in the contents of the yaml" do
-        YamlExtensions.stub(:yaml_hash).with("file.yml") { @yaml }
-        @h.should_receive(:merge_recursively).with(@yaml)
+        allow(YamlExtensions).to receive(:yaml_hash).with("file.yml") { @yaml }
+        expect(@h).to receive(:merge_recursively).with(@yaml)
         @h.merge_yaml("file.yml")
       end
     end
@@ -89,8 +89,8 @@ module AresMUSH
       it "should merge in the contents of the yaml in place" do
         yaml = {}
         h = {}
-        YamlExtensions.stub(:yaml_hash).with("file.yml") { yaml }
-        h.should_receive(:merge_recursively!).with(yaml)
+        allow(YamlExtensions).to receive(:yaml_hash).with("file.yml") { yaml }
+        expect(h).to receive(:merge_recursively!).with(yaml)
         h.merge_yaml!("file.yml")
       end
     end
@@ -98,27 +98,27 @@ module AresMUSH
     describe :deep_match do
       it "should match if there is a matching key" do
         h = { "abc" => "123" }
-        h.deep_match(/b/).should eq h
+        expect(h.deep_match(/b/)).to eq h
       end
       
       it "should match if there is a matching value" do
         h = { "abc" => "123" }
-        h.deep_match(/2/).should eq h
+        expect(h.deep_match(/2/)).to eq h
       end
       
       it "should match a sub-hash if there is a matching key" do
         h = { "abc" => {"def" => "123"} }
-        h.deep_match(/e/).should eq h
+        expect(h.deep_match(/e/)).to eq h
       end
       
       it "should match a sub-hash if there is a matching value" do
         h = { "abc" => {"def" => "123"} }
-        h.deep_match(/2/).should eq h
+        expect(h.deep_match(/2/)).to eq h
       end
       
       it "should not match when nothing suitable is found" do
         h = { "abc" => { "def" => "123"} }
-        h.deep_match(/g/).should be_empty
+        expect(h.deep_match(/g/)).to be_empty
       end
     end
   end

--- a/spec/core_ext/match_data_ext_specs.rb
+++ b/spec/core_ext/match_data_ext_specs.rb
@@ -10,7 +10,7 @@ module AresMUSH
         str = "a b"
         m = /(?<foo>.+) (?<bar>.+)/.match(str)
         data = { :foo => "a", :bar => "b" }
-        m.names_hash.should eq data
+        expect(m.names_hash).to eq data
       end
     end
   end

--- a/spec/core_ext/string_ext_specs.rb
+++ b/spec/core_ext/string_ext_specs.rb
@@ -8,132 +8,132 @@ module AresMUSH
 
     describe :first do
       it "returns the first part if there is a separator" do
-        "A:B".first(":").should eq "A"
+        expect("A:B".first(":")).to eq "A"
       end
 
       it "returns the whole string if there is no separator" do
-        "AB-C".first(":").should eq "AB-C"
+        expect("AB-C".first(":")).to eq "AB-C"
       end
 
       it "returns an empty string if the separator is at the front" do
-        ":AB".first(":").should eq ""
+        expect(":AB".first(":")).to eq ""
       end
     end
 
     describe :rest do
       it "returns the first part if there is a separator" do
-        "A:B:C:D".rest(":").should eq "B:C:D"
+        expect("A:B:C:D".rest(":")).to eq "B:C:D"
       end
 
       it "returns empty if there is no separator" do
-        "AB-C".rest(":").should eq ""
+        expect("AB-C".rest(":")).to eq ""
       end
 
       it "returns the rest of the string even if the separator is at the front" do
-        ":AB".rest(":").should eq "AB"
+        expect(":AB".rest(":")).to eq "AB"
       end
 
       it "returns an empty string if the only separator is at the end" do
-        "AB:".rest(":").should eq ""
+        expect("AB:".rest(":")).to eq ""
       end
 
       it "returns a properly joined string an extra seprator is at the end" do
-        "AB:C:".rest(":").should eq "C:"
+        expect("AB:C:".rest(":")).to eq "C:"
       end
     end
 
     describe :titlecase do
       it "should capitalize every word in the title" do
-        "a very long engagement".titlecase.should eq "A Very Long Engagement"
+        expect("a very long engagement".titlecase).to eq "A Very Long Engagement"
       end
     end
 
     describe :titlecase do
       it "should clean up funky spacing and capitalization" do
-        "    a VERY long ENgagEMent    ".titlecase.should eq "A Very Long Engagement"
+        expect("    a VERY long ENgagEMent    ".titlecase).to eq "A Very Long Engagement"
       end
     end
 
     describe :code_gsub do
       it "should replace a code" do
-        "A%rB".code_gsub("%r", "Z").should eq "AZB"
+        expect("A%rB".code_gsub("%r", "Z")).to eq "AZB"
       end
       
        it "should replace multiple instances of a code" do
-          "A%rB%r".code_gsub("%r", "Z").should eq "AZBZ"
+          expect("A%rB%r".code_gsub("%r", "Z")).to eq "AZBZ"
         end
         
       it "should be case-sensitive in its replacements" do
-          "A%R".code_gsub("%r", "Z").should eq "A%R"
+          expect("A%R".code_gsub("%r", "Z")).to eq "A%R"
        end
       
       it "should put in the raw code when preceeded by a single backslash" do
-        "A\\%rB".code_gsub("%r", "Z").should eq "A\\%rB"
+        expect("A\\%rB".code_gsub("%r", "Z")).to eq "A\\%rB"
       end
 
       it "should put in the raw code when preceeded by two backslashes" do
         x = "A\\\\%rB".code_gsub("%r", "Z")
-        x.should eq "A\\\\%rB" 
+        expect(x).to eq "A\\\\%rB" 
       end
 
       it "should put in the raw code when preceeded by two backslashes" do
-        "A\\\\%rB".code_gsub("%r", "Z").should eq "A\\\\%rB" 
+        expect("A\\\\%rB".code_gsub("%r", "Z")).to eq "A\\\\%rB" 
       end
     end
     
     describe :truncate do
       it "should truncate a string that is too long" do
-        "FOOBARBAZ".truncate(4).should eq "FOOB"
+        expect("FOOBARBAZ".truncate(4)).to eq "FOOB"
       end
       
       it "should do nothing to a string that is not too long" do
-        "FOOBARBAZ".truncate(10).should eq "FOOBARBAZ"
+        expect("FOOBARBAZ".truncate(10)).to eq "FOOBARBAZ"
       end
       
       it "should return empty if the string is empty" do
-        "".truncate(10).should eq ""
+        expect("".truncate(10)).to eq ""
       end      
     end
     
     describe :underscore do
       it "should translate CamelCase into undescores" do
-        "CamelCase".underscore.should eq "camel_case"
+        expect("CamelCase".underscore).to eq "camel_case"
       end
     end
     
     describe :is_integer? do
       it "should return true for a number" do
-        "1".is_integer?.should be true
+        expect("1".is_integer?).to be true
       end
       
       it "should return true for a multi-digit number" do
-        "123".is_integer?.should be true
+        expect("123".is_integer?).to be true
       end
       
       it "should return false for not a number" do
-        "x".is_integer?.should be false
+        expect("x".is_integer?).to be false
       end
       
       it "should return false for empty string" do
-        "".is_integer?.should be false
+        expect("".is_integer?).to be false
       end
       
       it "should return false for a float" do
-        "1.2".is_integer?.should be false
+        expect("1.2".is_integer?).to be false
       end
 
       it "should return false for a number mixed with string" do
-        "12ABC".is_integer?.should be false
+        expect("12ABC".is_integer?).to be false
       end
     end
     
     describe :repeat do
       it "should repeat the string x times" do
-        "x".repeat(5).should eq "xxxxx"
+        expect("x".repeat(5)).to eq "xxxxx"
       end
       
       it "should work with multiple chars" do
-        "ab".repeat(3).should eq "ababab"
+        expect("ab".repeat(3)).to eq "ababab"
       end
     end
     

--- a/spec/core_ext/yaml_ext_specs.rb
+++ b/spec/core_ext/yaml_ext_specs.rb
@@ -14,15 +14,15 @@ module AresMUSH
       end
       
       it "should read in the contents of the file" do
-        YAML.stub(:load) { @yaml }
-        File.should_receive(:open).with("file.yml") { @io }
+        allow(YAML).to receive(:load) { @yaml }
+        expect(File).to receive(:open).with("file.yml") { @io }
         YamlExtensions.yaml_hash("file.yml")
       end
       
       it "should load the YAML from the file" do
-        File.stub(:open).with("file.yml") { @io }
-        YAML.should_receive(:load).with(@io) { @yaml }
-        YamlExtensions.yaml_hash("file.yml").should eq @yaml
+        allow(File).to receive(:open).with("file.yml") { @io }
+        expect(YAML).to receive(:load).with(@io) { @yaml }
+        expect(YamlExtensions.yaml_hash("file.yml")).to eq @yaml
       end
     end
   end

--- a/spec/cron_specs.rb
+++ b/spec/cron_specs.rb
@@ -13,10 +13,10 @@ module AresMUSH
     describe :raise_event do
       it "should send the cron event with the current time" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
-        Time.stub(:now) { time }
-        dispatcher.should_receive(:on_event) do |event|
-          event.class.should eq CronEvent
-          event.time.should eq time
+        allow(Time).to receive(:now) { time }
+        expect(dispatcher).to receive(:on_event) do |event|
+          expect(event.class).to eq CronEvent
+          expect(event.time).to eq time
         end
         Cron.raise_event
       end
@@ -26,68 +26,68 @@ module AresMUSH
       it "should match a matching date" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "date" => [25] }
-        Cron.is_cron_match?(cron, time).should be true
+        expect(Cron.is_cron_match?(cron, time)).to be true
       end
 
       it "should not match a different date" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "date" => [26] }
-        Cron.is_cron_match?(cron, time).should be false
+        expect(Cron.is_cron_match?(cron, time)).to be false
       end
       
       it "should match a matching day of week" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "day_of_week" => ["sat"] }
-        Cron.is_cron_match?(cron, time).should be true
+        expect(Cron.is_cron_match?(cron, time)).to be true
       end
 
       it "should not match a different day of week" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "day_of_week" => ["sun"] }
-        Cron.is_cron_match?(cron, time).should be false
+        expect(Cron.is_cron_match?(cron, time)).to be false
       end
       
       it "should match a matching hour" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "hour" => [14] }
-        Cron.is_cron_match?(cron, time).should be true
+        expect(Cron.is_cron_match?(cron, time)).to be true
       end
 
       it "should not match a different hour" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "hour" => [17] }
-        Cron.is_cron_match?(cron, time).should be false
+        expect(Cron.is_cron_match?(cron, time)).to be false
       end
       
       it "should match a matching minute" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "minute" => [22] }
-        Cron.is_cron_match?(cron, time).should be true
+        expect(Cron.is_cron_match?(cron, time)).to be true
       end
 
       it "should not match a different minute" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "minute" => [27] }
-        Cron.is_cron_match?(cron, time).should be false
+        expect(Cron.is_cron_match?(cron, time)).to be false
       end
       
       
       it "should match a matching combo" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "minute" => [22], "hour" => [14], "date" => [25] }
-        Cron.is_cron_match?(cron, time).should be true
+        expect(Cron.is_cron_match?(cron, time)).to be true
       end
 
       it "should not match a different combo" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "minute" => [27], "hour" => [14], "date" => [25] }
-        Cron.is_cron_match?(cron, time).should be false
+        expect(Cron.is_cron_match?(cron, time)).to be false
       end
       
       it "should match any result in the list" do
         time = Time.new(2014, 01, 25, 14, 22, 17)
         cron = { "minute" => [4, 18, 22] }
-        Cron.is_cron_match?(cron, time).should be true
+        expect(Cron.is_cron_match?(cron, time)).to be true
       end
     end
   end   

--- a/spec/error_block_specs.rb
+++ b/spec/error_block_specs.rb
@@ -6,43 +6,43 @@ module AresMUSH
   describe "Error block" do
     before do
       @client = double
-      @client.stub(:id) { "1" }
-      SpecHelpers.stub_translate_for_testing
+      allow(@client).to receive(:id) { "1" }
+      stub_translate_for_testing
     end
     
     it "should catch an error and emit it to the client" do
-      @client.should_receive(:emit_failure).with 'dispatcher.unexpected_error'
+      expect(@client).to receive(:emit_failure).with 'dispatcher.unexpected_error'
       val = AresMUSH.with_error_handling(@client, "TEST") do
         raise "An error"
       end
-      val.should eq false
+      expect(val).to eq false
     end
     
     it "should not emit anything on success" do
-      @client.should_not_receive(:emit_failure)
+      expect(@client).to_not receive(:emit_failure)
       val = AresMUSH.with_error_handling(@client, "TEST") do
         x = 1 + 2
       end
-      val.should eq true
+      expect(val).to eq true
     end
     
     it "should not emit anything if client is nil" do
       val = AresMUSH.with_error_handling(nil, "TEST") do
         raise "An error"
       end
-      val.should eq false
+      expect(val).to eq false
     end
     
     it "should catch a double error" do
-      Global.logger.should_receive(:error)
-      Global.logger.should_receive(:error)
+      expect(Global.logger).to receive(:error)
+      expect(Global.logger).to receive(:error)
       client = double
-      client.stub(:id) { 1 }
-      client.should_receive(:emit_failure).and_raise("Double fault!")
+      allow(client).to receive(:id) { 1 }
+      expect(client).to receive(:emit_failure).and_raise("Double fault!")
       val = AresMUSH.with_error_handling(client, "TEST") do
         raise "An error"
       end
-      val.should eq false
+      expect(val).to eq false
     end
   end
 end

--- a/spec/formatters/ansi_formatter_specs.rb
+++ b/spec/formatters/ansi_formatter_specs.rb
@@ -8,55 +8,55 @@ module AresMUSH
     
     describe :get_code do
       it "should give code for lowercase x + valid letter" do
-        AnsiFormatter.get_code("%xr").should eq ANSI.red
+        expect(AnsiFormatter.get_code("%xr")).to eq ANSI.red
       end
 
       it "should give code for uppercase x + valid letter" do
-        AnsiFormatter.get_code("%Xb").should eq ANSI.blue
+        expect(AnsiFormatter.get_code("%Xb")).to eq ANSI.blue
       end
       
       it "should give code for lowercase c + valid letter" do
-        AnsiFormatter.get_code("%cr").should eq ANSI.red
+        expect(AnsiFormatter.get_code("%cr")).to eq ANSI.red
       end
 
       it "should give code for uppercase C + valid letter" do
-        AnsiFormatter.get_code("%Cb").should eq ANSI.blue
+        expect(AnsiFormatter.get_code("%Cb")).to eq ANSI.blue
       end
       
       it "should give code for background color" do
-        AnsiFormatter.get_code("%CB").should eq ANSI.on_blue
+        expect(AnsiFormatter.get_code("%CB")).to eq ANSI.on_blue
       end
       
       it "should give code for a 1-digit FANSI foreground" do
-        AnsiFormatter.get_code("%x1").should eq "\e[38;5;1m" 
+        expect(AnsiFormatter.get_code("%x1")).to eq "\e[38;5;1m" 
       end
 
       it "should give code for a 2-digit FANSI foreground" do
-        AnsiFormatter.get_code("%x12").should eq "\e[38;5;12m" 
+        expect(AnsiFormatter.get_code("%x12")).to eq "\e[38;5;12m" 
       end
 
       it "should give code for a 3-digit FANSI foreground" do
-        AnsiFormatter.get_code("%x123").should eq "\e[38;5;123m" 
+        expect(AnsiFormatter.get_code("%x123")).to eq "\e[38;5;123m" 
       end
       
       it "should give code for a FANSI background" do
-        AnsiFormatter.get_code("%X1").should eq "\e[48;5;1m" 
+        expect(AnsiFormatter.get_code("%X1")).to eq "\e[48;5;1m" 
       end
       
       it "should return nil if not ansi" do
-        AnsiFormatter.get_code("ABC").should be_nil
+        expect(AnsiFormatter.get_code("ABC")).to be_nil
       end
       
       it "should return nil if not a valid ansi letter code" do
-        AnsiFormatter.get_code("%xz").should be_nil
+        expect(AnsiFormatter.get_code("%xz")).to be_nil
       end
       
       it "should return nil if not a valid FANSI number" do
-        AnsiFormatter.get_code("999").should be_nil
+        expect(AnsiFormatter.get_code("999")).to be_nil
       end
 
       it "should return nil if FANSI number is too long" do
-        AnsiFormatter.get_code("9999").should be_nil
+        expect(AnsiFormatter.get_code("9999")).to be_nil
       end
       
     end

--- a/spec/formatters/line_specs.rb
+++ b/spec/formatters/line_specs.rb
@@ -6,18 +6,18 @@ module AresMUSH
   describe Line do
     describe :show do
       it "is defaults to showing header" do
-        Global.should_receive(:read_config).with("skin", "header") { "---" } 
-        Line.show.should eq "---"
+        expect(Global).to receive(:read_config).with("skin", "header") { "---" } 
+        expect(Line.show).to eq "---"
       end
       
       it "can read any arbitrary line" do
-        Global.should_receive(:read_config).with("skin", "line_top") { "---" } 
-        Line.show("line_top").should eq "---"
+        expect(Global).to receive(:read_config).with("skin", "line_top") { "---" } 
+        expect(Line.show("line_top")).to eq "---"
       end
       
       it "should default to a blank line if the specified one doesn't exist" do
-        Global.should_receive(:read_config).with("skin", "xxx") { nil } 
-        Line.show("xxx").should eq ""
+        expect(Global).to receive(:read_config).with("skin", "xxx") { nil } 
+        expect(Line.show("xxx")).to eq ""
       end
     end
   end

--- a/spec/formatters/mush_formatter_specs.rb
+++ b/spec/formatters/mush_formatter_specs.rb
@@ -6,18 +6,18 @@ module AresMUSH
 
   describe MushFormatter do
    def expect_msg(expected, actual)
-     actual.should eq expected + ANSI.reset + "\r\n"
+     expect(actual).to eq expected + ANSI.reset + "\r\n"
    end
    
     describe :format do
       before do
-        SubstitutionFormatter.stub(:format) do |msg|
+        allow(SubstitutionFormatter).to receive(:format) do |msg|
           msg
         end
       end
       
       it "should do MUSH substitutions" do
-        SubstitutionFormatter.should_receive(:format).with("msg", true) { "xmsg" }
+        expect(SubstitutionFormatter).to receive(:format).with("msg", true) { "xmsg" }
         msg = MushFormatter.format("msg")
         expect_msg("xmsg", msg)
       end

--- a/spec/formatters/pose_formatter_specs.rb
+++ b/spec/formatters/pose_formatter_specs.rb
@@ -9,31 +9,31 @@ module AresMUSH
     describe :format do
 
       it "should parse a say for a string starting with a quote" do
-        Locale.stub(:translate).with("object.say", :name => "Bob", :msg => "Hello.") { "hi" }
-        PoseFormatter.format("Bob", "\"Hello.").should eq "hi"
+        allow(Locale).to receive(:translate).with("object.say", :name => "Bob", :msg => "Hello.") { "hi" }
+        expect(PoseFormatter.format("Bob", "\"Hello.")).to eq "hi"
       end
 
       it "should parse a pose for a string starting with a colon" do
-        Locale.stub(:translate).with("object.pose", :name => "Bob", :msg => "waves.") { "waves" }
-        PoseFormatter.format("Bob", ":waves.").should eq "waves"
+        allow(Locale).to receive(:translate).with("object.pose", :name => "Bob", :msg => "waves.") { "waves" }
+        expect(PoseFormatter.format("Bob", ":waves.")).to eq "waves"
       end
 
       it "should parse a semipose for a string starting with a semicolon" do
-        Locale.stub(:translate).with("object.semipose", :name => "Bob", :msg => "'s cat.") { "cat" }
-        PoseFormatter.format("Bob", ";'s cat.").should eq "cat"
+        allow(Locale).to receive(:translate).with("object.semipose", :name => "Bob", :msg => "'s cat.") { "cat" }
+        expect(PoseFormatter.format("Bob", ";'s cat.")).to eq "cat"
       end
 
       it "should parse an emit for a string starting with a backslash" do
-        PoseFormatter.format("Bob", "\\Whee").should eq "Whee"
+        expect(PoseFormatter.format("Bob", "\\Whee")).to eq "Whee"
       end
 
       it "should parse an emit for a string starting with a backslash and space" do
-        PoseFormatter.format("Bob", "\\ Whee").should eq "Whee"
+        expect(PoseFormatter.format("Bob", "\\ Whee")).to eq "Whee"
       end
       
       it "should default to a say" do
-        Locale.stub(:translate).with("object.say", :name => "Bob", :msg => "Hello.") { "hi" }
-        PoseFormatter.format("Bob", "Hello.").should eq "hi"
+        allow(Locale).to receive(:translate).with("object.say", :name => "Bob", :msg => "Hello.") { "hi" }
+        expect(PoseFormatter.format("Bob", "Hello.")).to eq "hi"
       end
 
     end

--- a/spec/formatters/progress_bar_formatter_specs.rb
+++ b/spec/formatters/progress_bar_formatter_specs.rb
@@ -7,60 +7,60 @@ module AresMUSH
   describe ProgressBarFormatter do
     describe :format do
       it "should show zero progress" do
-        ProgressBarFormatter.format(0, 10).should eq ".........."
+        expect(ProgressBarFormatter.format(0, 10)).to eq ".........."
       end
 
       it "should show negative progress as zero" do
-        ProgressBarFormatter.format(-1, 10).should eq ".........."
+        expect(ProgressBarFormatter.format(-1, 10)).to eq ".........."
       end
 
       it "should handle nil progress" do
-        ProgressBarFormatter.format(nil, 10).should eq ".........."
+        expect(ProgressBarFormatter.format(nil, 10)).to eq ".........."
       end
             
       it "should show complete progress" do
-        ProgressBarFormatter.format(10, 10).should eq "@@@@@@@@@@"
+        expect(ProgressBarFormatter.format(10, 10)).to eq "@@@@@@@@@@"
       end
 
       it "should show excess progress as complete" do
-        ProgressBarFormatter.format(11, 10).should eq "@@@@@@@@@@"
+        expect(ProgressBarFormatter.format(11, 10)).to eq "@@@@@@@@@@"
       end
 
       it "should show partial progress" do
-        ProgressBarFormatter.format(5, 10).should eq "@@@@@....."
+        expect(ProgressBarFormatter.format(5, 10)).to eq "@@@@@....."
       end
 
       it "should round down partial progress" do
-        ProgressBarFormatter.format(5, 12).should eq "@@@@......"
+        expect(ProgressBarFormatter.format(5, 12)).to eq "@@@@......"
       end
 
       it "should not round down partial progress to zero" do
-        ProgressBarFormatter.format(1, 20).should eq "@........."
+        expect(ProgressBarFormatter.format(1, 20)).to eq "@........."
       end
 
       context "compressed scale of 5" do
         it "should show partial progress" do
-          ProgressBarFormatter.format(5, 10, 5).should eq "@@..."
+          expect(ProgressBarFormatter.format(5, 10, 5)).to eq "@@..."
         end
 
         it "should show complete progress" do
-          ProgressBarFormatter.format(10, 10, 5).should eq "@@@@@"
+          expect(ProgressBarFormatter.format(10, 10, 5)).to eq "@@@@@"
         end
       end
 
       context "compressed scale of 2" do
         it "should show partial progress" do
-          ProgressBarFormatter.format(5, 10, 2).should eq "@."
+          expect(ProgressBarFormatter.format(5, 10, 2)).to eq "@."
         end
 
         it "should show complete progress" do
-          ProgressBarFormatter.format(10, 10, 2).should eq "@@"
+          expect(ProgressBarFormatter.format(10, 10, 2)).to eq "@@"
         end
       end
       
       context "custom chars" do
         it "should let you override the display" do
-          ProgressBarFormatter.format(5, 10, 10, "*", "-").should eq "*****-----"
+          expect(ProgressBarFormatter.format(5, 10, 10, "*", "-")).to eq "*****-----"
         end
       end
       

--- a/spec/formatters/random_colorizer_specs.rb
+++ b/spec/formatters/random_colorizer_specs.rb
@@ -8,23 +8,23 @@ module AresMUSH
     
     describe :random_color do
       it "should pick the first color for the first bracket of time" do
-        Time.stub(:now) { Time.new(2007,11,1,15,25,10) }
-        RandomColorizer.random_color.should eq "%xc"
+        allow(Time).to receive(:now) { Time.new(2007,11,1,15,25,10) }
+        expect(RandomColorizer.random_color).to eq "%xc"
       end
       
       it "should pick the second color for the second bracket of time" do
-        Time.stub(:now) { Time.new(2007,11,1,15,25,20) }
-        RandomColorizer.random_color.should eq "%xb"
+        allow(Time).to receive(:now) { Time.new(2007,11,1,15,25,20) }
+        expect(RandomColorizer.random_color).to eq "%xb"
       end
       
       it "should pick the third color for the second bracket of time" do
-        Time.stub(:now) { Time.new(2007,11,1,15,25,40) }
-        RandomColorizer.random_color.should eq "%xg"
+        allow(Time).to receive(:now) { Time.new(2007,11,1,15,25,40) }
+        expect(RandomColorizer.random_color).to eq "%xg"
       end
       
       it "should pick the last color for the fourth bracket of time" do
-        Time.stub(:now) { Time.new(2007,11,1,15,25,55) }
-        RandomColorizer.random_color.should eq "%xr"
+        allow(Time).to receive(:now) { Time.new(2007,11,1,15,25,55) }
+        expect(RandomColorizer.random_color).to eq "%xr"
       end      
     end
   end

--- a/spec/formatters/substitution_formatter_specs.rb
+++ b/spec/formatters/substitution_formatter_specs.rb
@@ -6,7 +6,7 @@ module AresMUSH
 
   describe SubstitutionFormatter do
     before do
-      Line.stub(:show) { "" }
+      allow(Line).to receive(:show) { "" }
     end
     
     describe :perform_subs do
@@ -15,97 +15,97 @@ module AresMUSH
       end
 
       it "should replace %r and %R with linebreaks" do
-        SubstitutionFormatter.format("Test%rline%Rline2").should eq "Test\nline\nline2"
+        expect(SubstitutionFormatter.format("Test%rline%Rline2")).to eq "Test\nline\nline2"
       end
       
       it "should replace %b and %B with blank space" do
-        SubstitutionFormatter.format("Test%bblank%Bspace").should eq "Test blank space"
+        expect(SubstitutionFormatter.format("Test%bblank%Bspace")).to eq "Test blank space"
       end
 
       it "should replace %t and %T with 5 spaces" do
-        SubstitutionFormatter.format("Test%tTest2%TTest3").should eq "Test     Test2     Test3"
+        expect(SubstitutionFormatter.format("Test%tTest2%TTest3")).to eq "Test     Test2     Test3"
       end
 
       it "should replace %lh with header" do
-        Line.stub(:show).with("h") { "---" }
-        SubstitutionFormatter.format("Test%lhTest").should eq "Test---Test"
+        allow(Line).to receive(:show).with("h") { "---" }
+        expect(SubstitutionFormatter.format("Test%lhTest")).to eq "Test---Test"
       end    
 
       it "should replace %lf with footer" do
-        Line.stub(:show).with("f") { "---" }
-        SubstitutionFormatter.format("Test%lfTest").should eq "Test---Test"
+        allow(Line).to receive(:show).with("f") { "---" }
+        expect(SubstitutionFormatter.format("Test%lfTest")).to eq "Test---Test"
       end    
 
       it "should replace %ld with divider" do
-        Line.stub(:show).with("d") { "---" }
-        SubstitutionFormatter.format("Test%ldTest").should eq "Test---Test"
+        allow(Line).to receive(:show).with("d") { "---" }
+        expect(SubstitutionFormatter.format("Test%ldTest")).to eq "Test---Test"
       end    
 
       it "should replace %lp with plain line" do
-        Line.stub(:show).with("p") { "---" }
-        SubstitutionFormatter.format("Test%lpTest").should eq "Test---Test"
+        allow(Line).to receive(:show).with("p") { "---" }
+        expect(SubstitutionFormatter.format("Test%lpTest")).to eq "Test---Test"
       end  
       
       it "should replace %LP with plain line (case doesn't matter)" do
-        Line.stub(:show).with("P") { "---" }
-        SubstitutionFormatter.format("Test%LPTest").should eq "Test---Test"
+        allow(Line).to receive(:show).with("P") { "---" }
+        expect(SubstitutionFormatter.format("Test%LPTest")).to eq "Test---Test"
       end    
       
       it "should replace %x! with a random color" do
-        AresMUSH::RandomColorizer.should_receive(:random_color) { "%xb" }
-        SubstitutionFormatter.format("A%x!B").should eq "A" + ANSI.blue + "B"
+        expect(AresMUSH::RandomColorizer).to receive(:random_color) { "%xb" }
+        expect(SubstitutionFormatter.format("A%x!B")).to eq "A" + ANSI.blue + "B"
       end
 
       it "should replace %\\ with a \\" do
-        SubstitutionFormatter.format("A%\\B").should eq "A\\B"
+        expect(SubstitutionFormatter.format("A%\\B")).to eq "A\\B"
       end
       
       it "should replace space() with spaces" do
-        SubstitutionFormatter.format("A[space(1)]B[space(10)]").should eq "A B          "
+        expect(SubstitutionFormatter.format("A[space(1)]B[space(10)]")).to eq "A B          "
       end
 
       it "should replace center() with centered text" do
-        SubstitutionFormatter.format("[center(A,5)]B").should eq "  A  B"
+        expect(SubstitutionFormatter.format("[center(A,5)]B")).to eq "  A  B"
       end
       
       it "should replace center() with centered text with a padding char" do
-        SubstitutionFormatter.format("[center(A,6,.)]B").should eq "..A...B"
+        expect(SubstitutionFormatter.format("[center(A,6,.)]B")).to eq "..A...B"
       end
 
       it "should replace left() with left text with a padding char" do
-        SubstitutionFormatter.format("[left(A,6,.)]B").should eq "A.....B"
+        expect(SubstitutionFormatter.format("[left(A,6,.)]B")).to eq "A.....B"
       end
 
       it "should replace right() with right text with a padding char" do
-        SubstitutionFormatter.format("[right(A,6,.)]B").should eq ".....AB"
+        expect(SubstitutionFormatter.format("[right(A,6,.)]B")).to eq ".....AB"
       end
       
       it "should replace ansi() with ansi codes" do
-        SubstitutionFormatter.format("[ansi(hcB,A)]").should eq ANSI.bold + ANSI.cyan + ANSI.on_blue + "A" + ANSI.reset
+        expect(SubstitutionFormatter.format("[ansi(hcB,A)]")).to eq ANSI.bold + ANSI.cyan + ANSI.on_blue + "A" + ANSI.reset
       end
       
       it "should not replace an escaped linebreak or space" do
-        SubstitutionFormatter.format("Test\\%bblank\\%Rline").should eq "Test\\%bblank\\%Rline"
+        expect(SubstitutionFormatter.format("Test\\%bblank\\%Rline")).to eq "Test\\%bblank\\%Rline"
       end
       
       it "should replace nested codes" do
-        SubstitutionFormatter.format("A%xc%xGB%xnC").should eq "A" + ANSI.cyan + ANSI.on_green + "B" + ANSI.reset + "C" 
+        expect(SubstitutionFormatter.format("A%xc%xGB%xnC")).to eq "A" + ANSI.cyan + ANSI.on_green + "B" + ANSI.reset + "C" 
       end
 
       it "should not replace a code preceeded by a backslash" do
-        SubstitutionFormatter.format("A\\%xcB").should eq "A\\%xcB" 
+        expect(SubstitutionFormatter.format("A\\%xcB")).to eq "A\\%xcB" 
       end
       
       it "should handle a numeric code for foreground" do
-        SubstitutionFormatter.format("A%x102B").should eq "A\e[38;5;102mB" 
+        expect(SubstitutionFormatter.format("A%x102B")).to eq "A\e[38;5;102mB" 
       end
       
       it "should handle a numeric code for background" do
-        SubstitutionFormatter.format("A%C102B").should eq "A\e[48;5;102mB" 
+        expect(SubstitutionFormatter.format("A%C102B")).to eq "A\e[48;5;102mB" 
       end
       
       it "should handle a color code followed by a number" do
-        SubstitutionFormatter.format("A%Cg123B").should eq "A" + ANSI.green + "123B" 
+        expect(SubstitutionFormatter.format("A%Cg123B")).to eq "A" + ANSI.green + "123B" 
       end
       
     end
@@ -113,45 +113,45 @@ module AresMUSH
     
     describe :center do
       it "should truncate if the string is too long" do
-        SubstitutionFormatter.center("A%xc%xhGB%xnC", 2).should eq "A%xc%xhG%xnC"
+        expect(SubstitutionFormatter.center("A%xc%xhGB%xnC", 2)).to eq "A%xc%xhG%xnC"
       end
       
       it "should pad if the string is too short" do
-        SubstitutionFormatter.center("A%xc%xhGB%xnC", 10, ".").should eq "...A%xc%xhGB%xnC..."
+        expect(SubstitutionFormatter.center("A%xc%xhGB%xnC", 10, ".")).to eq "...A%xc%xhGB%xnC..."
       end
     end      
 
     describe :left do
       it "should truncate if the string is too long" do
-        SubstitutionFormatter.left("A%xc%xhGB%xnC", 2).should eq "A%xc%xhG%xnC"
+        expect(SubstitutionFormatter.left("A%xc%xhGB%xnC", 2)).to eq "A%xc%xhG%xnC"
       end
       
       it "should pad if the string is too short" do
-        SubstitutionFormatter.left("A%xc%xhGB%xnC", 10, ".").should eq "A%xc%xhGB%xnC......"
+        expect(SubstitutionFormatter.left("A%xc%xhGB%xnC", 10, ".")).to eq "A%xc%xhGB%xnC......"
       end
       
       it "should pad if the string is just right" do
-        SubstitutionFormatter.left("%xrABC%xn", 3).should eq "%xrABC%xn"
+        expect(SubstitutionFormatter.left("%xrABC%xn", 3)).to eq "%xrABC%xn"
       end
     end 
 
     describe :right do
       it "should truncate if the string is too long" do
-        SubstitutionFormatter.right("A%xc%xhGB%xnC", 2).should eq "A%xc%xhG%xnC"
+        expect(SubstitutionFormatter.right("A%xc%xhGB%xnC", 2)).to eq "A%xc%xhG%xnC"
       end
       
       it "should pad if the string is too short" do
-        SubstitutionFormatter.right("A%xc%xhGB%xnC", 10, ".").should eq "......A%xc%xhGB%xnC"
+        expect(SubstitutionFormatter.right("A%xc%xhGB%xnC", 10, ".")).to eq "......A%xc%xhGB%xnC"
       end
     end 
             
     describe :truncate do 
       it "should truncate a string that's too long" do
-        SubstitutionFormatter.truncate("A%xc%xhGB%xnC", 2).should eq "A%xc%xhG%xnC"
+        expect(SubstitutionFormatter.truncate("A%xc%xhGB%xnC", 2)).to eq "A%xc%xhG%xnC"
       end
       
       it "should do nothing for a string that's shorter than allowed" do
-        SubstitutionFormatter.truncate("A%xc%xhGB%xnC", 20).should eq "A%xc%xhGB%xnC"
+        expect(SubstitutionFormatter.truncate("A%xc%xhGB%xnC", 20)).to eq "A%xc%xhGB%xnC"
       end
     end
     

--- a/spec/formatters/time_formatter_specs.rb
+++ b/spec/formatters/time_formatter_specs.rb
@@ -7,28 +7,28 @@ module AresMUSH
   describe TimeFormatter do
     describe :format do
       it "should show a time less than 1 minute as seconds" do
-        Locale.stub(:translate).with('time.seconds', :time => 23)  { "23s" }
-        TimeFormatter.format(23).should eq "23s"
+        allow(Locale).to receive(:translate).with('time.seconds', :time => 23)  { "23s" }
+        expect(TimeFormatter.format(23)).to eq "23s"
       end
       
       it "should show a time between 1m and 60m as minutes" do
-        Locale.stub(:translate).with('time.minutes', :time => 2)  { "2m" }
-        TimeFormatter.format(120).should eq "2m"
+        allow(Locale).to receive(:translate).with('time.minutes', :time => 2)  { "2m" }
+        expect(TimeFormatter.format(120)).to eq "2m"
       end
       
       it "should show a time greater than 60m as hours" do
-        Locale.stub(:translate).with('time.hours', :time => 2)  { "2h" }
-        TimeFormatter.format(2 * 60 * 60).should eq "2h"
+        allow(Locale).to receive(:translate).with('time.hours', :time => 2)  { "2h" }
+        expect(TimeFormatter.format(2 * 60 * 60)).to eq "2h"
       end
       
       it "should show a time greater than 24h as days" do
-        Locale.stub(:translate).with('time.days', :time => 2)  { "2d" }
-        TimeFormatter.format(24 * 2 * 60 * 60).should eq "2d"
+        allow(Locale).to receive(:translate).with('time.days', :time => 2)  { "2d" }
+        expect(TimeFormatter.format(24 * 2 * 60 * 60)).to eq "2d"
       end
       
       it "should round fractional times" do
-        Locale.stub(:translate).with('time.days', :time => 2)  { "2d" }
-        TimeFormatter.format(24 * 2.1 * 60 * 60).should eq "2d"
+        allow(Locale).to receive(:translate).with('time.days', :time => 2)  { "2d" }
+        expect(TimeFormatter.format(24 * 2.1 * 60 * 60)).to eq "2d"
       end        
     end
   end

--- a/spec/hash_reader_specs.rb
+++ b/spec/hash_reader_specs.rb
@@ -12,8 +12,8 @@ module AresMUSH
         "b" => "2"
       }
       reader = HashReader.new(hash)
-      reader.a.should eq "1"
-      reader.b.should eq "2"
+      expect(reader.a).to eq "1"
+      expect(reader.b).to eq "2"
     end
     
     it "should provide method accessors for nested hashes" do
@@ -30,21 +30,21 @@ module AresMUSH
         "b" => "2"
       }
       reader = HashReader.new(hash)
-      reader.a.c.should eq 1
-      reader.a.d.e.should eq [1, 2]
-      reader.b.should eq "2"
+      expect(reader.a.c).to eq 1
+      expect(reader.a.d.e).to eq [1, 2]
+      expect(reader.b).to eq "2"
     end
     
     it "should return nil if the accessor is not found" do
       reader = HashReader.new({"a" => "b"})
-      reader.x.should eq nil
+      expect(reader.x).to eq nil
     end
     
     describe :raw_hash do
       it "should provide access to the raw hash" do
         hash = {"a" => "b"}
         reader = HashReader.new(hash)
-        reader.raw_hash.should eq hash
+        expect(reader.raw_hash).to eq hash
       end
     end
   end

--- a/spec/locale/locale_loader_specs.rb
+++ b/spec/locale/locale_loader_specs.rb
@@ -7,39 +7,39 @@ module AresMUSH
   describe LocaleLoader do
     describe :load_dir do
       it "should do nothing if the dir doesn't exist" do
-        Dir.stub(:exist?).with("dir") { false }
-        LocaleLoader.should_not_receive(:load_file)
+        allow(Dir).to receive(:exist?).with("dir") { false }
+        expect(LocaleLoader).to_not receive(:load_file)
         LocaleLoader.load_dir("dir")
       end
       
       it "should load each file in the dir" do
-        Dir.stub(:exist?).with("dir") { true }
-        Dir.stub(:foreach).with("dir").and_yield("a").and_yield("b")
-        LocaleLoader.should_receive(:load_file).with(File.join("dir", "a"))
-        LocaleLoader.should_receive(:load_file).with(File.join("dir", "b"))
+        allow(Dir).to receive(:exist?).with("dir") { true }
+        allow(Dir).to receive(:foreach).with("dir").and_yield("a").and_yield("b")
+        expect(LocaleLoader).to receive(:load_file).with(File.join("dir", "a"))
+        expect(LocaleLoader).to receive(:load_file).with(File.join("dir", "b"))
         LocaleLoader.load_dir("dir")
       end
     end
     
     describe :load_files do
       it "should load each file" do
-        LocaleLoader.should_receive(:load_file).with("f1")
-        LocaleLoader.should_receive(:load_file).with("f2")        
+        expect(LocaleLoader).to receive(:load_file).with("f1")
+        expect(LocaleLoader).to receive(:load_file).with("f2")        
         LocaleLoader.load_files(["f1", "f2"])
       end
     end
     
     describe :load_file do
       it "should do nothing if the file is a directory" do
-        File.stub(:directory?).with("f") { true }
-        I18n.load_path.should_not_receive(:<<).with("f")
+        allow(File).to receive(:directory?).with("f") { true }
+        expect(I18n.load_path).to_not receive(:<<).with("f")
         LocaleLoader.load_file("f")
       end
 
       it "should pass along a regular file to the backend" do
-        AresLogger.stub(:create_log_dir) {} 
-        File.stub(:directory?).with("f") { false }
-        I18n.load_path.should_receive(:<<).with("f")
+        allow(AresLogger).to receive(:create_log_dir) {} 
+        allow(File).to receive(:directory?).with("f") { false }
+        expect(I18n.load_path).to receive(:<<).with("f")
         LocaleLoader.load_file("f")
       end
     end

--- a/spec/locale/locale_specs.rb
+++ b/spec/locale/locale_specs.rb
@@ -7,55 +7,55 @@ module AresMUSH
   describe Locale do
     before do
       @root_path = Dir.pwd
-      AresMUSH.stub(:root_path) { @root_path }
+      allow(AresMUSH).to receive(:root_path) { @root_path }
       @locale = Locale.new
     end
     
     describe :locale_path do
       it "should be the game dir plus the locale dir" do
-        Locale.locale_path.should eq File.join(@root_path, "engine", "locales")
+        expect(Locale.locale_path).to eq File.join(@root_path, "engine", "locales")
       end
     end
 
     describe :locale do
       it "should return the I18 locale" do
-        I18n.stub(:locale) { 'hu' }
-        @locale.locale.should eq 'hu'
+        allow(I18n).to receive(:locale) { 'hu' }
+        expect(@locale.locale).to eq 'hu'
       end
     end
     
     describe :default_locale do
       it "should return the I18 default locale" do
-        I18n.stub(:default_locale) { 'hu' }
-        @locale.default_locale.should eq 'hu'
+        allow(I18n).to receive(:default_locale) { 'hu' }
+        expect(@locale.default_locale).to eq 'hu'
       end
     end
     
     describe :setup do
       before do
-        Global.stub(:read_config).with("locale", "locale") { "de" } 
-        Global.stub(:read_config).with("locale", "default_locale") { "en" } 
-        I18n.stub(:locale=)
-        I18n.stub(:default_locale=)
+        allow(Global).to receive(:read_config).with("locale", "locale") { "de" } 
+        allow(Global).to receive(:read_config).with("locale", "default_locale") { "en" } 
+        allow(I18n).to receive(:locale=)
+        allow(I18n).to receive(:default_locale=)
       end
 
       it "should trigger a load" do
-        I18n.should_receive(:reload!)
+        expect(I18n).to receive(:reload!)
         @locale.setup
       end
       
       it "should set the locale from the config file" do
-        I18n.should_receive(:locale=).with("de")
+        expect(I18n).to receive(:locale=).with("de")
         @locale.setup
       end
       
       it "should set the fallback locale from the config file" do
-        I18n.should_receive(:default_locale=).with("en")
+        expect(I18n).to receive(:default_locale=).with("en")
         @locale.setup
       end   
       
       it "should extend the I18n library with the fallback code" do
-        I18n::Backend::Simple.should_receive(:send).with(:include, I18n::Backend::Fallbacks)
+        expect(I18n::Backend::Simple).to receive(:send).with(:include, I18n::Backend::Fallbacks)
         @locale.setup
       end
       
@@ -63,63 +63,63 @@ module AresMUSH
     
     describe :t do
       it "should return the backend's translation" do
-        I18n.should_receive(:t).with('hello world') { "Hello World!" }
-        t('hello world').should eq "Hello World!"
+        expect(I18n).to receive(:t).with('hello world') { "Hello World!" }
+        expect(t('hello world')).to eq "Hello World!"
       end
       
       it "should pass along variables in the string" do
         args = { :arg => "the arg" }
-        I18n.should_receive(:t).with('hello arg', args) { "Hello World with the arg!" }
+        expect(I18n).to receive(:t).with('hello arg', args) { "Hello World with the arg!" }
         t('hello arg', args )
       end      
     end
     
     describe :l do
       it "should replace . with the number format separator" do
-        I18n.should_receive(:t).with('number.format.separator') { "," }
-        l("100.3").should eq "100,3"  
+        expect(I18n).to receive(:t).with('number.format.separator') { "," }
+        expect(l("100.3")).to eq "100,3"  
       end
       
       it "should return the I18n localization of a date" do
         date = Date.new
-        I18n.should_receive(:l).with(date, {}) { "abc" }
-        l(date).should eq "abc"
+        expect(I18n).to receive(:l).with(date, {}) { "abc" }
+        expect(l(date)).to eq "abc"
       end
       
       it "should return the I18n localization of a time" do
         time = Time.new
-        I18n.should_receive(:l).with(time, {}) { "abc" }
-        l(time).should eq "abc"
+        expect(I18n).to receive(:l).with(time, {}) { "abc" }
+        expect(l(time)).to eq "abc"
       end
     end
     
     describe :delocalize do
      it "should delocalize a number" do
-        I18n.should_receive(:t).with('number.format.separator') { "," }
-        @locale.delocalize("100,23").should eq "100.23"
+        expect(I18n).to receive(:t).with('number.format.separator') { "," }
+        expect(@locale.delocalize("100,23")).to eq "100.23"
       end
       
       it "should delocalize a date to the same value" do
         date = Date.new
-        @locale.delocalize(date).should eq date.to_s
+        expect(@locale.delocalize(date)).to eq date.to_s
       end
 
       it "should delocalize a time to the same value" do
         time = Time.new
-        @locale.delocalize(time).should eq time.to_s
+        expect(@locale.delocalize(time)).to eq time.to_s
       end
       
     end
     
     describe :reset_load_path do
       it "should tell the backend to clear the load path" do
-        I18n.should_receive(:load_path=).with([])
+        expect(I18n).to receive(:load_path=).with([])
         @locale.reset_load_path
       end
 
       it "should tell the loader to load the main locale" do
-        @locale.stub(:locale_order) { [ "en" ]}
-        LocaleLoader.should_receive(:load_file).with(File.join(@root_path, "engine", "locales", "locale_en.yml"))
+        allow(@locale).to receive(:locale_order) { [ "en" ]}
+        expect(LocaleLoader).to receive(:load_file).with(File.join(@root_path, "engine", "locales", "locale_en.yml"))
         @locale.reset_load_path
       end
       
@@ -127,7 +127,7 @@ module AresMUSH
     
     describe :reload do
       it "should tell the backend to reload" do
-        I18n.should_receive(:reload!)
+        expect(I18n).to receive(:reload!)
         @locale.reload
       end
     end

--- a/spec/models/character_specs.rb
+++ b/spec/models/character_specs.rb
@@ -6,18 +6,18 @@ module AresMUSH
 
   describe Character do
     before do
-      SpecHelpers.stub_translate_for_testing
+      stub_translate_for_testing
     end
     
     describe :found? do
       it "should return true if there is an existing char" do
-        Character.stub(:find_one_by_name).with("Bob") { double }
-        Character.found?("Bob").should be true
+        allow(Character).to receive(:find_one_by_name).with("Bob") { double }
+        expect(Character.found?("Bob")).to be true
       end
       
       it "should return false if no char exists" do
-        Character.stub(:find_one_by_name).with("Bob") { false }
-        Character.found?("Bob").should be false
+        allow(Character).to receive(:find_one_by_name).with("Bob") { false }
+        expect(Character.found?("Bob")).to be false
       end
     end 
 
@@ -28,46 +28,46 @@ module AresMUSH
         @role_a = Role.new(name: "A")
         @role_b = Role.new(name: "B")
         
-        Role.stub(:find_one_by_name).with("A") { @role_a }
-        Role.stub(:find_one_by_name).with("B") { @role_b }
-        Role.stub(:find_one_by_name).with("C") { double }
-        Role.stub(:find_one_by_name).with("D") { double }
+        allow(Role).to receive(:find_one_by_name).with("A") { @role_a }
+        allow(Role).to receive(:find_one_by_name).with("B") { @role_b }
+        allow(Role).to receive(:find_one_by_name).with("C") { double }
+        allow(Role).to receive(:find_one_by_name).with("D") { double }
       end
     
       describe :has_role? do
         before do
-          @char.stub(:roles) { [@role_a] }
+          allow(@char).to receive(:roles) { [@role_a] }
         end
         
         it "should return true if the character has the role" do
-          @char.has_role?("A").should be true
+          expect(@char.has_role?("A")).to be true
         end
 
         it "should return false if they don't" do
-          @char.has_role?("B").should be false
+          expect(@char.has_role?("B")).to be false
         end
 
         it "should search by role class as well as name" do
-          @char.has_role?(@role_a).should be true
-          @char.has_role?(@role_b).should be false
+          expect(@char.has_role?(@role_a)).to be true
+          expect(@char.has_role?(@role_b)).to be false
         end
         
       end
     
       describe :has_any_role? do
         before do
-          @char.stub(:roles) { [ @role_a, @role_b ] }
+          allow(@char).to receive(:roles) { [ @role_a, @role_b ] }
         end
         it "should return true if the character has a role in the list" do
-          @char.has_any_role?([ "B", "C" ]).should be true
+          expect(@char.has_any_role?([ "B", "C" ])).to be true
         end
       
         it "should return false if they don't" do
-          @char.has_any_role?([ "C", "D" ]).should be false
+          expect(@char.has_any_role?([ "C", "D" ])).to be false
         end
       
         it "should accept a single role" do
-          @char.has_any_role?( "B" ).should be true        
+          expect(@char.has_any_role?( "B" )).to be true        
         end
       end
     
@@ -80,26 +80,26 @@ module AresMUSH
       end
       
       it "should display the name by itself" do
-        @char.ooc_name.should eq "Bob"
+        expect(@char.ooc_name).to eq "Bob"
       end
       
 
       it "should display a char with a public handle" do
-        @char.stub(:handle) {@handle}
-        @char.ooc_name.should eq "Bob (@Star)"
+        allow(@char).to receive(:handle) {@handle}
+        expect(@char.ooc_name).to eq "Bob (@Star)"
       end
       
       it "should display a char with a public handle and alias" do
-        @char.stub(:handle) {@handle}
+        allow(@char).to receive(:handle) {@handle}
         @char.alias = "B"
-        @char.ooc_name.should eq "Bob (@Star)"
+        expect(@char.ooc_name).to eq "Bob (@Star)"
       end
       
       it "should display public handle matching name" do
-        @char.stub(:handle) {@handle}
+        allow(@char).to receive(:handle) {@handle}
         @char.name = "Star"
         @char.alias = "B"
-        @char.ooc_name.should eq "Star (@Star)"
+        expect(@char.ooc_name).to eq "Star (@Star)"
       end
     end
      

--- a/spec/models/game_specs.rb
+++ b/spec/models/game_specs.rb
@@ -8,8 +8,8 @@ module AresMUSH
     describe :master do
       it "should return the master game object" do
         model = double
-        Game.stub(:[]).with(1) { model }
-        Game.master.should eq model
+        allow(Game).to receive(:[]).with(1) { model }
+        expect(Game.master).to eq model
       end
     end
 

--- a/spec/models/room_specs.rb
+++ b/spec/models/room_specs.rb
@@ -16,50 +16,50 @@ module AresMUSH
       @char3 = double
       
       client_monitor = double
-      @char1.stub(:room) { @room }
-      @char2.stub(:room) { @room }
-      @char3.stub(:room) { double }
+      allow(@char1).to receive(:room) { @room }
+      allow(@char2).to receive(:room) { @room }
+      allow(@char3).to receive(:room) { double }
     end
     
     describe :get_exit do
       it "should return exit if exit exists - case-insensitive" do
         exit1 = Exit.new(:name_upcase => "A",)
         exit2 = Exit.new(:name_upcase => "B")
-        @room.stub(:exits) { [ exit1, exit2 ]}
-        @room.get_exit("a").name_upcase.should eq "A"
-        @room.get_exit("B").name_upcase.should eq "B"
-        @room.get_exit("C").should eq nil
+        allow(@room).to receive(:exits) { [ exit1, exit2 ]}
+        expect(@room.get_exit("a").name_upcase).to eq "A"
+        expect(@room.get_exit("B").name_upcase).to eq "B"
+        expect(@room.get_exit("C")).to eq nil
       end
       
       it "should return exit if exit exists even when alias exists" do
         exit1 = Exit.new(:name_upcase => "A", :alias_upcase => "B")
         exit2 = Exit.new(:name_upcase => "B")
-        @room.stub(:exits) { [ exit1, exit2 ]}
-        @room.get_exit("B").name_upcase.should eq "B"
+        allow(@room).to receive(:exits) { [ exit1, exit2 ]}
+        expect(@room.get_exit("B").name_upcase).to eq "B"
       end
 
       it "should return exit if alias exists" do
         exit1 = Exit.new(:name_upcase => "A", :alias_upcase => "C")
         exit2 = Exit.new(:name_upcase => "B")
-        @room.stub(:exits) { [ exit1, exit2 ]}
-        @room.get_exit("C").name_upcase.should eq "A"
+        allow(@room).to receive(:exits) { [ exit1, exit2 ]}
+        expect(@room.get_exit("C").name_upcase).to eq "A"
       end
     end
     
     describe :way_out do 
       it "should return the exit with name 'O' if it exists" do
         ex = double
-        @room.stub(:get_exit).with("O") { ex }
-        @room.way_out.should eq ex
+        allow(@room).to receive(:get_exit).with("O") { ex }
+        expect(@room.way_out).to eq ex
       end
       
       it "should return first exit if 'O' doesn't exist" do
 
         exit1 = Exit.new(:name_upcase => "A")
         exit2 = Exit.new(:name_upcase => "B")
-        @room.stub(:exits) { [ exit1, exit2 ]}
+        allow(@room).to receive(:exits) { [ exit1, exit2 ]}
         
-        @room.way_out.name_upcase.should eq "A"
+        expect(@room.way_out.name_upcase).to eq "A"
       end
     end
     

--- a/spec/plugin/command_handler_specs.rb
+++ b/spec/plugin/command_handler_specs.rb
@@ -48,7 +48,7 @@ module AresMUSH
         end
       end
       
-      SpecHelpers.stub_translate_for_testing 
+      stub_translate_for_testing 
     end
     
     after do
@@ -60,11 +60,11 @@ module AresMUSH
         cmd = double
         char = double
         client = double
-        client.should_receive(:to_s) { "client" }
-        cmd.should_receive(:to_s) { "Cmd" }
-        char.stub(:name) { "Bob" }
+        expect(client).to receive(:to_s) { "client" }
+        expect(cmd).to receive(:to_s) { "Cmd" }
+        allow(char).to receive(:name) { "Bob" }
         @handler = PluginSpecTest.new(client, cmd, char)
-        Global.logger.should_receive(:debug).with("AresMUSH::PluginSpecTest: client Enactor=Bob Cmd=Cmd")
+        expect(Global.logger).to receive(:debug).with("AresMUSH::PluginSpecTest: client Enactor=Bob Cmd=Cmd")
         @handler.log_command
       end
     end
@@ -75,39 +75,39 @@ module AresMUSH
         @cmd = double
         @char = double
         @room = double
-        @client.stub(:char_id) { 22 }
-        Character.stub(:find) { @char }
-        @char.stub(:room) { @room }
-        @cmd.stub(:raw) { "raw" }
-        @cmd.stub(:switch) { nil }
-        @cmd.stub(:root) { "root" }
-        @char.stub(:name) { "Bob" }
-        @cmd.stub(:root_plus_switch) { "root/switch" }
-        @client.stub(:logged_in?) { true }
+        allow(@client).to receive(:char_id) { 22 }
+        allow(Character).to receive(:find) { @char }
+        allow(@char).to receive(:room) { @room }
+        allow(@cmd).to receive(:raw) { "raw" }
+        allow(@cmd).to receive(:switch) { nil }
+        allow(@cmd).to receive(:root) { "root" }
+        allow(@char).to receive(:name) { "Bob" }
+        allow(@cmd).to receive(:root_plus_switch) { "root/switch" }
+        allow(@client).to receive(:logged_in?) { true }
         @handler = PluginSpecTest.new(@client, @cmd, @char)
       end
       
       it "should parse the args" do
-        @handler.should_receive(:parse_args)
+        expect(@handler).to receive(:parse_args)
         @handler.on_command
       end
       
       it "should log the command" do
-        @handler.stub(:check) { nil }
-        @handler.should_receive(:log_command)
+        allow(@handler).to receive(:check) { nil }
+        expect(@handler).to receive(:log_command)
         @handler.on_command
       end
         
       it "should fail if not logged in" do
-        @client.stub(:logged_in?) { false }
-        @client.should_receive(:emit_failure).with("dispatcher.must_be_logged_in")
+        allow(@client).to receive(:logged_in?) { false }
+        expect(@client).to receive(:emit_failure).with("dispatcher.must_be_logged_in")
         @handler.on_command
       end
         
       it "should not fail if not logged in when the command allows it" do
         @handler = PluginSpecTestAllowWithoutLogin.new(@client, @cmd, @char)
-        @client.stub(:logged_in?) { false }
-        @client.should_not_receive(:emit_failure)
+        allow(@client).to receive(:logged_in?) { false }
+        expect(@client).to_not receive(:emit_failure)
         @handler.on_command
       end
       
@@ -115,7 +115,7 @@ module AresMUSH
         @handler = PluginSpecTestRequiredArgs.new(@client, @cmd, @char)
         @handler.foo = nil
         @handler.bar = "here"
-        @client.should_receive(:emit_failure).with("dispatcher.invalid_syntax")
+        expect(@client).to receive(:emit_failure).with("dispatcher.invalid_syntax")
         @handler.on_command
       end
       
@@ -123,7 +123,7 @@ module AresMUSH
         @handler = PluginSpecTestRequiredArgs.new(@client, @cmd, @char)
         @handler.foo = "here"
         @handler.bar = "    "
-        @client.should_receive(:emit_failure).with("dispatcher.invalid_syntax")
+        expect(@client).to receive(:emit_failure).with("dispatcher.invalid_syntax")
         @handler.on_command
       end
       
@@ -131,43 +131,43 @@ module AresMUSH
         @handler = PluginSpecTestRequiredArgs.new(@client, @cmd, @char)
         @handler.foo = "here"
         @handler.bar = "there"
-        @client.should_not_receive(:emit_failure)
+        expect(@client).to_not receive(:emit_failure)
         @handler.on_command
       end
       
       it "should not care about required args if none are specified" do
         @handler.x = nil
         @handler.y = "     "
-        @client.should_not_receive(:emit_failure)
+        expect(@client).to_not receive(:emit_failure)
         @handler.on_command
       end
       
       
       it "should call all check methods but do nothing if they return nil" do
-        @handler.should_receive(:check_x) { nil }
-        @handler.should_receive(:check_y) { nil }
-        @client.should_not_receive(:emit_failure)
+        expect(@handler).to receive(:check_x) { nil }
+        expect(@handler).to receive(:check_y) { nil }
+        expect(@client).to_not receive(:emit_failure)
         @handler.on_command
       end
       
       it "should emit an error and stop if any validator fails" do
         @handler.x = "x marks the spot"
-        @client.should_receive(:emit_failure).with("error_x")
-        @handler.should_not_receive(:handle)
+        expect(@client).to receive(:emit_failure).with("error_x")
+        expect(@handler).to_not receive(:handle)
         @handler.on_command
       end
       
       it "should emit an error and stop if any validator fails" do
         @handler.y = "y marks the spot"
-        @client.should_receive(:emit_failure).with("error_y")
-        @handler.should_not_receive(:handle)
+        expect(@client).to receive(:emit_failure).with("error_y")
+        expect(@handler).to_not receive(:handle)
         @handler.on_command
       end
       
       it "should handle the command if it's valid" do
-        @handler.stub(:check) { nil }
-        @client.should_not_receive(:emit_failure)
-        @handler.should_receive(:handle)
+        allow(@handler).to receive(:check) { nil }
+        expect(@client).to_not receive(:emit_failure)
+        expect(@handler).to receive(:handle)
         @handler.on_command
       end    
     end  
@@ -178,11 +178,11 @@ module AresMUSH
       end
       
       it "should return nil for nil" do
-        @handler.trim_arg(nil).should eq nil
+        expect(@handler.trim_arg(nil)).to eq nil
       end
       
       it "should return a /help/d string" do
-        @handler.trim_arg("   someTHING   ").should eq "someTHING"
+        expect(@handler.trim_arg("   someTHING   ")).to eq "someTHING"
       end
     end
     
@@ -192,11 +192,11 @@ module AresMUSH
       end
       
       it "should return nil for nil" do
-        @handler.titlecase_arg(nil).should eq nil
+        expect(@handler.titlecase_arg(nil)).to eq nil
       end
       
       it "should return a /help/d string" do
-        @handler.titlecase_arg("   someTHING   ").should eq "Something"
+        expect(@handler.titlecase_arg("   someTHING   ")).to eq "Something"
       end
     end
   end

--- a/spec/plugin/plugin_manager_specs.rb
+++ b/spec/plugin/plugin_manager_specs.rb
@@ -9,31 +9,31 @@ module AresMUSH
     
     before do
       stub_global_objects
-      AresMUSH.stub(:game_path) { "/game" }      
+      allow(AresMUSH).to receive(:game_path) { "/game" }      
       @manager = PluginManager.new
-      Global.stub(:read_config).with("plugins", "disabled_plugins") { [] }
+      allow(Global).to receive(:read_config).with("plugins", "disabled_plugins") { [] }
     end
     
     describe :load_plugin_locale do
       it "should load all the plugin config files for all locales in order" do
         plugin = double
-        plugin.stub(:plugin_dir) { "A" }
-        locale.stub(:locale_order) { [ "l1", "l2" ]}
-        File.stub(:exists?).with("A/locales/locale_l1.yml") { true }
-        File.stub(:exists?).with("A/locales/locale_l2.yml") { true }
-        locale.should_receive(:add_locale_file).with("A/locales/locale_l1.yml")
-        locale.should_receive(:add_locale_file).with("A/locales/locale_l2.yml")
+        allow(plugin).to receive(:plugin_dir) { "A" }
+        allow(locale).to receive(:locale_order) { [ "l1", "l2" ]}
+        allow(File).to receive(:exists?).with("A/locales/locale_l1.yml") { true }
+        allow(File).to receive(:exists?).with("A/locales/locale_l2.yml") { true }
+        expect(locale).to receive(:add_locale_file).with("A/locales/locale_l1.yml")
+        expect(locale).to receive(:add_locale_file).with("A/locales/locale_l2.yml")
         @manager.load_plugin_locale plugin
       end
       
       it "should not load a plugin file if it doesn't exist" do
         plugin = double
-        plugin.stub(:plugin_dir) { "A" }
-        locale.stub(:locale_order) { [ "l1", "l2" ]}
-        File.stub(:exists?).with("A/locales/locale_l1.yml") { true }
-        File.stub(:exists?).with("A/locales/locale_l2.yml") { false }
-        locale.should_receive(:add_locale_file).with("A/locales/locale_l1.yml")
-        locale.should_not_receive(:add_locale_file).with("A/locales/locale_l2.yml")
+        allow(plugin).to receive(:plugin_dir) { "A" }
+        allow(locale).to receive(:locale_order) { [ "l1", "l2" ]}
+        allow(File).to receive(:exists?).with("A/locales/locale_l1.yml") { true }
+        allow(File).to receive(:exists?).with("A/locales/locale_l2.yml") { false }
+        expect(locale).to receive(:add_locale_file).with("A/locales/locale_l1.yml")
+        expect(locale).to_not receive(:add_locale_file).with("A/locales/locale_l2.yml")
         @manager.load_plugin_locale plugin
       end
     end    
@@ -41,25 +41,25 @@ module AresMUSH
     describe :load_plugin_help do
       it "should load all the plugin help files" do
         plugin = double
-        Dir.stub(:[]).with("A/help/en/**.md") { [ "h1", "h2" ] }
-        plugin.stub(:plugin_dir) { "A" }
-        plugin.stub(:to_s) { "AresMUSH::A" }
-        locale.stub(:locale_order) { ["en"] }
-        help_reader.should_receive(:load_help_file).with("h1", "A")
-        help_reader.should_receive(:load_help_file).with("h2", "A")
+        allow(Dir).to receive(:[]).with("A/help/en/**.md") { [ "h1", "h2" ] }
+        allow(plugin).to receive(:plugin_dir) { "A" }
+        allow(plugin).to receive(:to_s) { "AresMUSH::A" }
+        allow(locale).to receive(:locale_order) { ["en"] }
+        expect(help_reader).to receive(:load_help_file).with("h1", "A")
+        expect(help_reader).to receive(:load_help_file).with("h2", "A")
         @manager.load_plugin_help plugin
       end
       
       it "should read the specific locale and the default one" do
         plugin = double
-        Dir.stub(:[]).with("A/help/en/**.md") { [ "en/h1", "en/h2" ] }
-        Dir.stub(:[]).with("A/help/de/**.md") { [ "de/h1" ] }
-        plugin.stub(:plugin_dir) { "A" }
-        plugin.stub(:to_s) { "AresMUSH::A" }
-        locale.stub(:locale_order) { ["de", "en"] }
-        help_reader.should_receive(:load_help_file).with("de/h1", "A").ordered
-        help_reader.should_receive(:load_help_file).with("en/h1", "A").ordered
-        help_reader.should_receive(:load_help_file).with("en/h2", "A").ordered
+        allow(Dir).to receive(:[]).with("A/help/en/**.md") { [ "en/h1", "en/h2" ] }
+        allow(Dir).to receive(:[]).with("A/help/de/**.md") { [ "de/h1" ] }
+        allow(plugin).to receive(:plugin_dir) { "A" }
+        allow(plugin).to receive(:to_s) { "AresMUSH::A" }
+        allow(locale).to receive(:locale_order) { ["de", "en"] }
+        expect(help_reader).to receive(:load_help_file).with("de/h1", "A").ordered
+        expect(help_reader).to receive(:load_help_file).with("en/h1", "A").ordered
+        expect(help_reader).to receive(:load_help_file).with("en/h2", "A").ordered
         @manager.load_plugin_help plugin
       end
     end 
@@ -68,25 +68,25 @@ module AresMUSH
       it "should merge all the plugin shortcuts" do
         p1 = double
         p2 = double      
-        @manager.stub(:plugins) { [p1, p2] }
+        allow(@manager).to receive(:plugins) { [p1, p2] }
         
-        p1.stub(:shortcuts) { { a: 1, b: 2 } }
-        p2.stub(:shortcuts) { { c: 3, d: 4 } }
+        allow(p1).to receive(:shortcuts) { { a: 1, b: 2 } }
+        allow(p2).to receive(:shortcuts) { { c: 3, d: 4 } }
         
         expected = { a: 1, b: 2, c: 3, d: 4 }
-        @manager.shortcuts.should eq expected
+        expect(@manager.shortcuts).to eq expected
       end
       
       it "should not blow up on a plugin with no shortcuts" do
         p1 = double
         p2 = double      
-        @manager.stub(:plugins) { [p1, p2] }
+        allow(@manager).to receive(:plugins) { [p1, p2] }
         
-        p1.stub(:shortcuts) { { a: 1, b: 2 } }
-        p2.stub(:shortcuts) { nil }
+        allow(p1).to receive(:shortcuts) { { a: 1, b: 2 } }
+        allow(p2).to receive(:shortcuts) { nil }
         
         expected = { a: 1, b: 2 }
-        @manager.shortcuts.should eq expected
+        expect(@manager.shortcuts).to eq expected
       end
     end
     

--- a/spec/plugin_helpers/any_target_finder_specs.rb
+++ b/spec/plugin_helpers/any_target_finder_specs.rb
@@ -7,45 +7,45 @@ module AresMUSH
     describe :find do
       before do
         @client = double
-        Exit.stub(:find_any_by_name) { [] }
-        Room.stub(:find_any_by_name) { [] }
-        Character.stub(:find_any_by_name) { [] }
-        VisibleTargetFinder.stub(:find) { FindResult.new(nil, "Error") }
+        allow(Exit).to receive(:find_any_by_name) { [] }
+        allow(Room).to receive(:find_any_by_name) { [] }
+        allow(Character).to receive(:find_any_by_name) { [] }
+        allow(VisibleTargetFinder).to receive(:find) { FindResult.new(nil, "Error") }
       end
 
       it "should give preference to visible targets" do
         result = FindResult.new(double, nil)
-        VisibleTargetFinder.should_receive(:find).with("A", @client) { result }
-        AnyTargetFinder.find("A", @client).should eq result
+        expect(VisibleTargetFinder).to receive(:find).with("A", @client) { result }
+        expect(AnyTargetFinder.find("A", @client)).to eq result
       end
       
       it "should ensure only a single result" do
         room = double
-        room.stub(:id) { 1 }
-        @client.stub(:room) { room }
+        allow(room).to receive(:id) { 1 }
+        allow(@client).to receive(:room) { room }
         char1 = double
         char2 = double
         exit = double
         room = double
-        Character.should_receive(:find_any_by_name).with("A") { [char1, char2] }
-        Exit.should_receive(:find_any_by_name).with("A") { [exit] }
-        Room.should_receive(:find_any_by_name).with("A") { [room] }
+        expect(Character).to receive(:find_any_by_name).with("A") { [char1, char2] }
+        expect(Exit).to receive(:find_any_by_name).with("A") { [exit] }
+        expect(Room).to receive(:find_any_by_name).with("A") { [room] }
         result = FindResult.new(nil, "an error")
-        SingleResultSelector.should_receive(:select).with([char1, char2, exit, room]) { result }
-        AnyTargetFinder.find("A", @client).should eq result
+        expect(SingleResultSelector).to receive(:select).with([char1, char2, exit, room]) { result }
+        expect(AnyTargetFinder.find("A", @client)).to eq result
       end
 
       it "should remove nil results before selecting single target" do
         room = double
-        room.stub(:id) { 1 }
-        @client.stub(:room) { room }
+        allow(room).to receive(:id) { 1 }
+        allow(@client).to receive(:room) { room }
         char = double
-        Character.stub(:find_any_by_name) { [char] }
-        Exit.stub(:find_any_by_name) { [nil] }
-        Room.stub(:find_any_by_name) { [] }
+        allow(Character).to receive(:find_any_by_name) { [char] }
+        allow(Exit).to receive(:find_any_by_name) { [nil] }
+        allow(Room).to receive(:find_any_by_name) { [] }
         result = FindResult.new(char, nil)
-        SingleResultSelector.should_receive(:select).with([char]) { result }
-        AnyTargetFinder.find("A", @client).should eq result      
+        expect(SingleResultSelector).to receive(:select).with([char]) { result }
+        expect(AnyTargetFinder.find("A", @client)).to eq result      
       end
     end
   end

--- a/spec/plugin_helpers/class_target_finder_specs.rb
+++ b/spec/plugin_helpers/class_target_finder_specs.rb
@@ -10,7 +10,7 @@ module AresMUSH
       include SpecHelpers
 
       before do
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
     
       describe :find do
@@ -20,56 +20,56 @@ module AresMUSH
         
         it "should find the specified class by name" do
           room = double
-          Room.stub(:find_any_by_name).with("foo") { [room] }
+          allow(Room).to receive(:find_any_by_name).with("foo") { [room] }
           result = ClassTargetFinder.find("foo", Room, @viewer)
-          result.target.should eq room
-          result.error.should be_nil
+          expect(result.target).to eq room
+          expect(result.error).to be_nil
         end
     
         it "should return ambiguous if multiple results" do
-          Room.stub(:find_any_by_name).with("foo") { [double, double] }
+          allow(Room).to receive(:find_any_by_name).with("foo") { [double, double] }
           result = ClassTargetFinder.find("foo", Room, @viewer)
-          result.target.should eq nil
-          result.error.should eq 'db.object_ambiguous'
+          expect(result.target).to eq nil
+          expect(result.error).to eq 'db.object_ambiguous'
         end
 
         it "should return not found if no results" do
-          Room.stub(:find_any_by_name).with("bar") { [] }
+          allow(Room).to receive(:find_any_by_name).with("bar") { [] }
           result = ClassTargetFinder.find("bar", Room, @viewer)
-          result.target.should eq nil
-          result.error.should eq 'db.object_not_found'
+          expect(result.target).to eq nil
+          expect(result.error).to eq 'db.object_not_found'
         end
       
         it "should return the char for the me keword" do
           result = ClassTargetFinder.find("me", Character, @viewer)
-          result.target.should eq @viewer
-          result.error.should be_nil
+          expect(result.target).to eq @viewer
+          expect(result.error).to be_nil
         end
 
         it "should not return the char for another kind of object" do
           char = double
-          @viewer.stub(:char) { char }
-          Room.stub(:find_any_by_name).with("me") { [] }
+          allow(@viewer).to receive(:char) { char }
+          allow(Room).to receive(:find_any_by_name).with("me") { [] }
           result = ClassTargetFinder.find("me", Room, @viewer)
-          result.target.should eq nil
-          result.error.should eq 'db.object_not_found'
+          expect(result.target).to eq nil
+          expect(result.error).to eq 'db.object_not_found'
         end
       
         it "should return the char's location for the here keyword" do
           room = double
-          @viewer.stub(:room) { room }
+          allow(@viewer).to receive(:room) { room }
           result = ClassTargetFinder.find("here", Room, @viewer)
-          result.target.should eq room
-          result.error.should be_nil
+          expect(result.target).to eq room
+          expect(result.error).to be_nil
         end
       
         it "should not find here for another kind of object" do
           room = double
-          @viewer.stub(:room) { room }
-          Character.stub(:find_any_by_name).with("here") { [] }
+          allow(@viewer).to receive(:room) { room }
+          allow(Character).to receive(:find_any_by_name).with("here") { [] }
           result = ClassTargetFinder.find("here", Character, @viewer)
-          result.target.should eq nil
-          result.error.should eq 'db.object_not_found'
+          expect(result.target).to eq nil
+          expect(result.error).to eq 'db.object_not_found'
         end
       end
 
@@ -78,30 +78,30 @@ module AresMUSH
           @viewer = double
           @client = double
           @char = double
-          @char.stub(:name) { "char name" }
+          allow(@char).to receive(:name) { "char name" }
         end
       
         it "should emit failure if the char doesn't exist" do
           result = FindResult.new(nil, "error msg")
-          ClassTargetFinder.should_receive(:find).with("name", Character, @viewer) { result }
-          @client.should_receive(:emit_failure).with("error msg")
+          expect(ClassTargetFinder).to receive(:find).with("name", Character, @viewer) { result }
+          expect(@client).to receive(:emit_failure).with("error msg")
           ClassTargetFinder.with_a_character("name", @client, @viewer) do |char|
             raise "Should not get here."
           end
         end
       
         it "should not call the block with the char if it doesn't exist" do
-          ClassTargetFinder.stub(:find) { FindResult.new(nil, nil) }
-          @client.stub(:emit_failure)
+          allow(ClassTargetFinder).to receive(:find) { FindResult.new(nil, nil) }
+          allow(@client).to receive(:emit_failure)
           ClassTargetFinder.with_a_character("name", @client, @viewer) do |char|
             raise "Should not get here."
           end
         end
             
         it "should call the block with the char if it exists" do
-          ClassTargetFinder.stub(:find) { FindResult.new(@char, nil) }
+          allow(ClassTargetFinder).to receive(:find) { FindResult.new(@char, nil) }
           ClassTargetFinder.with_a_character("name", @client, @viewer) do |char|
-            char.name.should eq "char name"
+            expect(char.name).to eq "char name"
           end
         end
       end

--- a/spec/plugin_helpers/on_off_option_specs.rb
+++ b/spec/plugin_helpers/on_off_option_specs.rb
@@ -1,31 +1,31 @@
 module AresMUSH
   describe :OnOffOption do
     before do
-      SpecHelpers.stub_translate_for_testing
+      stub_translate_for_testing
     end
     
     it "should say on is on and valid" do
       option = OnOffOption.new("on")
-      option.is_on?.should be true
-      option.validate.should be_nil
+      expect(option.is_on?).to be true
+      expect(option.validate).to be_nil
     end
 
     it "should say off is off and valid" do
       option = OnOffOption.new("off")
-      option.is_on?.should be false
-      option.validate.should be_nil
+      expect(option.is_on?).to be false
+      expect(option.validate).to be_nil
     end
     
     it "should say a random value is off and invalid" do
       option = OnOffOption.new("foo")
-      option.is_on?.should be false
-      option.validate.should eq "dispatcher.invalid_on_off_option"
+      expect(option.is_on?).to be false
+      expect(option.validate).to eq "dispatcher.invalid_on_off_option"
     end
     
     it "should ignore case and spaces" do
       option = OnOffOption.new("   On   ")
-      option.is_on?.should be true
-      option.validate.should be_nil
+      expect(option.is_on?).to be true
+      expect(option.validate).to be_nil
     end
   end
 end

--- a/spec/plugin_helpers/online_char_finder_specs.rb
+++ b/spec/plugin_helpers/online_char_finder_specs.rb
@@ -12,117 +12,117 @@ module AresMUSH
         @client2 = double
         @char1 = double
         @char2 = double
-        Global.stub(:client_monitor) { @client_monitor }
-        SpecHelpers.stub_translate_for_testing
+        allow(Global).to receive(:client_monitor) { @client_monitor }
+        stub_translate_for_testing
       end
      
       it "should return the client for the me keword" do
         char = double
-        @client.stub(:char) { char }
+        allow(@client).to receive(:char) { char }
         result = OnlineCharFinder.find("me", @client)
-        result.target.client.should eq @client
-        result.target.char.should eq char
-        result.error.should be_nil
+        expect(result.target.client).to eq @client
+        expect(result.target.char).to eq char
+        expect(result.error).to be_nil
       end
 
       it "should return a matching online char" do
-        @char1.stub(:name_upcase) { "HARVEY" }
-        @char1.stub(:alias_upcase) { nil }
-        @char2.stub(:name_upcase) { "BOB" }
-        @char2.stub(:alias_upcase) { nil }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1, @client2 => @char2 }}
+        allow(@char1).to receive(:name_upcase) { "HARVEY" }
+        allow(@char1).to receive(:alias_upcase) { nil }
+        allow(@char2).to receive(:name_upcase) { "BOB" }
+        allow(@char2).to receive(:alias_upcase) { nil }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1, @client2 => @char2 }}
         result = OnlineCharFinder.find("bo", @client)
-        result.target.client.should eq @client2
-        result.target.char.should eq @char2
-        result.error.should be_nil
+        expect(result.target.client).to eq @client2
+        expect(result.target.char).to eq @char2
+        expect(result.error).to be_nil
       end
       
       it "should return a matching online char by alias" do
-        @char1.stub(:name_upcase) { "HARVEY" }
-        @char1.stub(:alias_upcase) { "HVY" }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1 }}
+        allow(@char1).to receive(:name_upcase) { "HARVEY" }
+        allow(@char1).to receive(:alias_upcase) { "HVY" }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1 }}
         result = OnlineCharFinder.find("hvy", @client)
-        result.target.client.should eq @client1
-        result.target.char.should eq @char1
-        result.error.should be_nil
+        expect(result.target.client).to eq @client1
+        expect(result.target.char).to eq @char1
+        expect(result.error).to be_nil
       end
       
       
       it "should ensure only a single result" do
-        @char1.stub(:name_upcase) { "ANNE" }
-        @char2.stub(:name_upcase) { "ANNA" }
-        @char1.stub(:alias_upcase) { nil }
-        @char2.stub(:alias_upcase) { nil }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1, @client2 => @char2 }}
+        allow(@char1).to receive(:name_upcase) { "ANNE" }
+        allow(@char2).to receive(:name_upcase) { "ANNA" }
+        allow(@char1).to receive(:alias_upcase) { nil }
+        allow(@char2).to receive(:alias_upcase) { nil }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1, @client2 => @char2 }}
         result = OnlineCharFinder.find("Ann", @client)
-        result.target.should be_nil
-        result.error.should eq "db.ambiguous_char_online"
+        expect(result.target).to be_nil
+        expect(result.error).to eq "db.ambiguous_char_online"
       end
       
       it "should match someone's actual name even if a partial name also exists" do
-        @char1.stub(:name_upcase) { "ANN" }
-        @char2.stub(:name_upcase) { "ANNA" }
-        @char1.stub(:alias_upcase) { nil }
-        @char2.stub(:alias_upcase) { nil }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1, @client2 => @char2 }}
+        allow(@char1).to receive(:name_upcase) { "ANN" }
+        allow(@char2).to receive(:name_upcase) { "ANNA" }
+        allow(@char1).to receive(:alias_upcase) { nil }
+        allow(@char2).to receive(:alias_upcase) { nil }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1, @client2 => @char2 }}
         result = OnlineCharFinder.find("Ann", @client)
-        result.target.client.should eq @client1
-        result.target.char.should eq @char1
-        result.error.should be_nil
+        expect(result.target.client).to eq @client1
+        expect(result.target.char).to eq @char1
+        expect(result.error).to be_nil
       end
       
       it "should match a handle if allowed to" do
-        @char1.stub(:name_upcase) { "HARVEY" }
-        @char1.stub(:alias_upcase) { "HVY" }
-        @char1.stub(:handle) { "@Nemo" }
-        @char1.stub(:handle_visible_to?).with(@client) { true }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1 }}
+        allow(@char1).to receive(:name_upcase) { "HARVEY" }
+        allow(@char1).to receive(:alias_upcase) { "HVY" }
+        allow(@char1).to receive(:handle) { "@Nemo" }
+        allow(@char1).to receive(:handle_visible_to?).with(@client) { true }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1 }}
         result = OnlineCharFinder.find("@Nemo", @client, true)
-        result.target.client.should eq @client1
-        result.target.char.should eq @char1
-        result.error.should be_nil
+        expect(result.target.client).to eq @client1
+        expect(result.target.char).to eq @char1
+        expect(result.error).to be_nil
       end
       
       it "should match part of a handle if allowed to" do
-        @char1.stub(:name_upcase) { "HARVEY" }
-        @char1.stub(:alias_upcase) { "HVY" }
-        @char1.stub(:handle) { "@Nemo" }
-        @char1.stub(:handle_visible_to?).with(@client) { true }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1 }}
+        allow(@char1).to receive(:name_upcase) { "HARVEY" }
+        allow(@char1).to receive(:alias_upcase) { "HVY" }
+        allow(@char1).to receive(:handle) { "@Nemo" }
+        allow(@char1).to receive(:handle_visible_to?).with(@client) { true }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1 }}
         result = OnlineCharFinder.find("@Nem", @client, true)
-        result.target.client.should eq @client1
-        result.target.char.should eq @char1
-        result.error.should be_nil
+        expect(result.target.client).to eq @client1
+        expect(result.target.char).to eq @char1
+        expect(result.error).to be_nil
       end
       
       it "should not match a handle if not allowed" do
-        @char1.stub(:name_upcase) { "HARVEY" }
-        @char1.stub(:alias_upcase) { "HVY" }
-        @char1.stub(:handle) { "@Nemo" }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1 }}
+        allow(@char1).to receive(:name_upcase) { "HARVEY" }
+        allow(@char1).to receive(:alias_upcase) { "HVY" }
+        allow(@char1).to receive(:handle) { "@Nemo" }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1 }}
         result = OnlineCharFinder.find("@Nemo", @client, false)
-        result.target.should be_nil
-        result.error.should eq "db.no_char_online_found"
+        expect(result.target).to be_nil
+        expect(result.error).to eq "db.no_char_online_found"
       end     
       
       it "should not match a handle if handle can't be seen" do
-        @char1.stub(:name_upcase) { "HARVEY" }
-        @char1.stub(:alias_upcase) { "HVY" }
-        @char1.stub(:handle) { "@Nemo" }
-        @char1.stub(:handle_visible_to?).with(@client) { false }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1 }}
+        allow(@char1).to receive(:name_upcase) { "HARVEY" }
+        allow(@char1).to receive(:alias_upcase) { "HVY" }
+        allow(@char1).to receive(:handle) { "@Nemo" }
+        allow(@char1).to receive(:handle_visible_to?).with(@client) { false }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1 }}
         result = OnlineCharFinder.find("@Nemo", @client, false)
-        result.target.should be_nil
-        result.error.should eq "db.no_char_online_found"
+        expect(result.target).to be_nil
+        expect(result.error).to eq "db.no_char_online_found"
       end      
       
       it "should return failure result if nothing found" do
-        @char1.stub(:name_upcase) { "ANNE" }
-        @char1.stub(:alias_upcase) { nil }
-        @client_monitor.stub(:logged_in) { {@client1 => @char1 }}
+        allow(@char1).to receive(:name_upcase) { "ANNE" }
+        allow(@char1).to receive(:alias_upcase) { nil }
+        allow(@client_monitor).to receive(:logged_in) { {@client1 => @char1 }}
         result = OnlineCharFinder.find("Bob", @client)
-        result.target.should be_nil
-        result.error.should eq "db.no_char_online_found"
+        expect(result.target).to be_nil
+        expect(result.error).to eq "db.no_char_online_found"
       end
     end
     
@@ -133,8 +133,8 @@ module AresMUSH
       
       it "should emit failure if a char doesn't exist" do
         result = FindResult.new(nil, "error msg")
-        OnlineCharFinder.should_receive(:find).with("n1", @client, false) { result }
-        @client.should_receive(:emit_failure).with("error msg")
+        expect(OnlineCharFinder).to receive(:find).with("n1", @client, false) { result }
+        expect(@client).to receive(:emit_failure).with("error msg")
         OnlineCharFinder.with_online_chars(["n1", "n2"], @client) do |clients|
           raise "Should not get here."
         end
@@ -143,10 +143,10 @@ module AresMUSH
       it "should call the block with the clients if they exist" do
         client1 = double
         client2 = double
-        OnlineCharFinder.should_receive(:find).with("n1", @client, false) { FindResult.new(client1, nil) }
-        OnlineCharFinder.should_receive(:find).with("n2", @client, false) { FindResult.new(client2, nil) }
+        expect(OnlineCharFinder).to receive(:find).with("n1", @client, false) { FindResult.new(client1, nil) }
+        expect(OnlineCharFinder).to receive(:find).with("n2", @client, false) { FindResult.new(client2, nil) }
         OnlineCharFinder.with_online_chars(["n1", "n2"], @client) do |clients|
-          clients.should eq [client1, client2]
+          expect(clients).to eq [client1, client2]
         end
       end
     end

--- a/spec/plugin_helpers/single_result_selector_specs.rb
+++ b/spec/plugin_helpers/single_result_selector_specs.rb
@@ -7,43 +7,43 @@ module AresMUSH
   describe SingleResultSelector do
     describe :select do
       before do
-        SpecHelpers.stub_translate_for_testing
+        stub_translate_for_testing
       end
 
       it "should return a failure if given something that doesn't support array indexing" do
         result = SingleResultSelector.select("123") 
-        result.target.should be_nil
-        result.error.should eq("db.object_not_found")
+        expect(result.target).to be_nil
+        expect(result.error).to eq("db.object_not_found")
       end
 
       it "should return false and emit failure if given something that doesn't support empty/count" do
         result = SingleResultSelector.select(123)
-        result.target.should be_nil
-        result.error.should eq("db.object_not_found")
+        expect(result.target).to be_nil
+        expect(result.error).to eq("db.object_not_found")
       end
 
       it "should return false and emit failure for an ambiguous result" do
         result = SingleResultSelector.select([1, 2]) 
-        result.target.should be_nil
-        result.error.should eq("db.object_ambiguous")
+        expect(result.target).to be_nil
+        expect(result.error).to eq("db.object_ambiguous")
       end
 
       it "should return false and emit failure for an empty result" do
         result = SingleResultSelector.select([])
-        result.target.should be_nil
-        result.error.should eq("db.object_not_found")
+        expect(result.target).to be_nil
+        expect(result.error).to eq("db.object_not_found")
       end
 
       it "should return false and emit failure for a nil result" do
         result = SingleResultSelector.select(nil)
-        result.target.should be_nil
-        result.error.should eq("db.object_not_found")
+        expect(result.target).to be_nil
+        expect(result.error).to eq("db.object_not_found")
       end
 
       it "should return a singular result" do
         result = SingleResultSelector.select([2])
-        result.target.should eq 2
-        result.error.should be_nil
+        expect(result.target).to eq 2
+        expect(result.error).to be_nil
       end
     end
   end

--- a/spec/plugin_helpers/visible_target_finder_specs.rb
+++ b/spec/plugin_helpers/visible_target_finder_specs.rb
@@ -7,52 +7,52 @@ module AresMUSH
     describe :find do
       before do
         @char = double
-        Exit.stub(:where) { [] }
-        Character.stub(:where) { [] }
+        allow(Exit).to receive(:where) { [] }
+        allow(Character).to receive(:where) { [] }
       end
 
       it "should return the char for the me keword" do
         result = VisibleTargetFinder.find("me", @char)
-        result.target.should eq @char
-        result.error.should be_nil
+        expect(result.target).to eq @char
+        expect(result.error).to be_nil
       end
 
       it "should return the char's location for the here keyword" do
         room = double
-        @char.stub(:room) { room }
+        allow(@char).to receive(:room) { room }
         result = VisibleTargetFinder.find("here", @char)
-        result.target.should eq room
-        result.error.should be_nil
+        expect(result.target).to eq room
+        expect(result.error).to be_nil
       end
       
       it "should ensure only a single result" do
         room = double
-        room.stub(:id) { 1 }
-        @char.stub(:room) { room }
+        allow(room).to receive(:id) { 1 }
+        allow(@char).to receive(:room) { room }
         char1 = double
         char2 = double
         exit = double
-        char1.stub(:room) { room }
-        char2.stub(:room) { room }
-        exit.stub(:source) { room }
-        Character.should_receive(:find_any_by_name).with("A") { [char1, char2] }
-        Exit.should_receive(:find_any_by_name).with("A") { [exit] }
+        allow(char1).to receive(:room) { room }
+        allow(char2).to receive(:room) { room }
+        allow(exit).to receive(:source) { room }
+        expect(Character).to receive(:find_any_by_name).with("A") { [char1, char2] }
+        expect(Exit).to receive(:find_any_by_name).with("A") { [exit] }
         result = FindResult.new(nil, "an error")
-        SingleResultSelector.should_receive(:select).with([char1, char2, exit]) { result }
-        VisibleTargetFinder.find("A", @char).should eq result      
+        expect(SingleResultSelector).to receive(:select).with([char1, char2, exit]) { result }
+        expect(VisibleTargetFinder.find("A", @char)).to eq result      
       end
 
       it "should remove nil results before selecting single target" do
         room = double
-        room.stub(:id) { 1 }
-        @char.stub(:room) { room }
+        allow(room).to receive(:id) { 1 }
+        allow(@char).to receive(:room) { room }
         char1 = double
-        char1.stub(:room) { room }
-        Character.stub(:find_any_by_name) { [char1] }
-        Exit.stub(:find_any_by_name) { [] }
+        allow(char1).to receive(:room) { room }
+        allow(Character).to receive(:find_any_by_name) { [char1] }
+        allow(Exit).to receive(:find_any_by_name) { [] }
         result = FindResult.new(char1, nil)
-        SingleResultSelector.should_receive(:select).with([char1]) { result }
-        VisibleTargetFinder.find("A", @char).should eq result      
+        expect(SingleResultSelector).to receive(:select).with([char1]) { result }
+        expect(VisibleTargetFinder.find("A", @char)).to eq result      
       end
     end
     
@@ -60,30 +60,30 @@ module AresMUSH
       before do
         @client = double
         @object = double
-        @object.stub(:name) { "obj name" }
+        allow(@object).to receive(:name) { "obj name" }
       end
       
       it "should emit failure if the object isn't visible" do
         result = FindResult.new(nil, "error msg")
-        VisibleTargetFinder.should_receive(:find).with("name", @char) { result }
-        @client.should_receive(:emit_failure).with("error msg")
+        expect(VisibleTargetFinder).to receive(:find).with("name", @char) { result }
+        expect(@client).to receive(:emit_failure).with("error msg")
         VisibleTargetFinder.with_something_visible("name", @client, @char) do |obj|
           raise "Should not get here."
         end
       end
       
       it "should not call the block with the object if it doesn't exist" do
-        VisibleTargetFinder.stub(:find) { FindResult.new(nil, nil) }
-        @client.stub(:emit_failure)
+        allow(VisibleTargetFinder).to receive(:find) { FindResult.new(nil, nil) }
+        allow(@client).to receive(:emit_failure)
         VisibleTargetFinder.with_something_visible("name", @client, @char) do |obj|
           raise "Should not get here."
         end
       end
             
       it "should call the block with the char if it exists" do
-        VisibleTargetFinder.stub(:find) { FindResult.new(@object, nil) }
+        allow(VisibleTargetFinder).to receive(:find) { FindResult.new(@object, nil) }
         VisibleTargetFinder.with_something_visible("name", @client, @char) do |obj|
-          @object.name.should eq "obj name"
+          expect(@object.name).to eq "obj name"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,17 +27,17 @@ module AresMUSH
   
   module SpecHelpers
         
-    def self.stub_translate_for_testing
+    def stub_translate_for_testing
       # Simple helper to stub out translations.  Only works well if you 
       # have a simple string because it doesn't do anything with the args
-      AresMUSH::Locale.stub(:translate) do |str|
+      allow(AresMUSH::Locale).to receive(:translate) do |str|
         "#{str}"
       end
     end    
     
-    def self.setup_mock_client(client, char)
-      client.stub(:char) { char }
-      char.stub(:client) { client }
+    def setup_mock_client(client, char)
+      allow(client).to receive(:char) { char }
+      allow(char).to receive(:client) { client }
     end
   end  
   
@@ -53,13 +53,13 @@ module AresMUSH
       @help_reader = double
       @notifier = double
       
-      Global.stub(:notifier) { @notifier }
-      Global.stub(:config_reader) { @config_reader }
-      Global.stub(:client_monitor) { @client_monitor }
-      Global.stub(:dispatcher) { @dispatcher }
-      Global.stub(:plugin_manager) { @plugin_manager }
-      Global.stub(:locale) { @locale }
-      Global.stub(:help_reader) { @help_reader }
+      allow(Global).to receive(:notifier) { @notifier }
+      allow(Global).to receive(:config_reader) { @config_reader }
+      allow(Global).to receive(:client_monitor) { @client_monitor }
+      allow(Global).to receive(:dispatcher) { @dispatcher }
+      allow(Global).to receive(:plugin_manager) { @plugin_manager }
+      allow(Global).to receive(:locale) { @locale }
+      allow(Global).to receive(:help_reader) { @help_reader }
     end
   end  
 end

--- a/spec/telnet_negotiation_specs.rb
+++ b/spec/telnet_negotiation_specs.rb
@@ -15,15 +15,15 @@ module AresMUSH
       it "should ignore a telnet NAWS control code" do
         data = [ 255, 251, 31, 0x30, 0x31, 0x32 ]
         str = data.map { |d| d.chr }.join
-        @negotaitor.handle_input(str).should eq "012"
+        expect(@negotaitor.handle_input(str)).to eq "012"
       end
       
       it "should shandle a NAWS response with the window size" do
         data = [ 255, 250, 31, 0, 80, 0, 24, 255, 240, 0x30, 0x31, 0x32 ]
         str = data.map { |d| d.chr }.join
-        @connection.should_receive(:window_width=).with(80)
-        @connection.should_receive(:window_height=).with(24)
-        @negotaitor.handle_input(str).should eq "012"
+        expect(@connection).to receive(:window_width=).with(80)
+        expect(@connection).to receive(:window_height=).with(24)
+        expect(@negotaitor.handle_input(str)).to eq "012"
       end
     end
     
@@ -32,8 +32,8 @@ module AresMUSH
         data = [ 255, 251, 42, 0x30, 0x31, 0x32 ]
         str = data.map { |d| d.chr }.join
         expected = [ 255, 250, 42, 1, ' '.ord, 'u'.ord, 't'.ord, 'f'.ord, '-'.ord, '8'.ord, 255, 240 ]
-        @connection.should_receive(:send_data).with( expected.map { |e| e.chr }.join)
-        @negotaitor.handle_input(str).should eq "012"
+        expect(@connection).to receive(:send_data).with( expected.map { |e| e.chr }.join)
+        expect(@negotaitor.handle_input(str)).to eq "012"
       end
     end
   end

--- a/spec/templates/template_formatters_specs.rb
+++ b/spec/templates/template_formatters_specs.rb
@@ -9,33 +9,33 @@ module AresMUSH
     include TemplateFormatters
     
     before do 
-      Line.stub(:show) { "" }
+      allow(Line).to receive(:show) { "" }
     end
     
     describe :right do
       it "should right justify a string" do
-        right("FOO", 5).should eq "  FOO"
+        expect(right("FOO", 5)).to eq "  FOO"
       end
       it "should trim a string that's too long" do
-        right("FOOBAR", 5).should eq "FOOBA"
+        expect(right("FOOBAR", 5)).to eq "FOOBA"
       end
     end
   
     describe :left do
       it "should left justify a string" do
-        left("FOO", 5).should eq "FOO  "
+        expect(left("FOO", 5)).to eq "FOO  "
       end
       it "should trim a string that's too long" do
-        left("FOOBAR", 5).should eq "FOOBA"
+        expect(left("FOOBAR", 5)).to eq "FOOBA"
       end
     end
   
     describe :center do
       it "should center a string" do
-        center("FOO", 5).should eq " FOO "
+        expect(center("FOO", 5)).to eq " FOO "
       end
       it "should trim a string that's too long" do
-        center("FOOBAR", 5).should eq "FOOBA"
+        expect(center("FOOBAR", 5)).to eq "FOOBA"
       end
     end    
   end


### PR DESCRIPTION
…x to expect syntax and stub syntax to allow syntax

When you run the suite, it gives you this set of deprecation warnings:
```
Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /home/ares/aresmush/plugins/channels/specs/channel_alias_specs.rb:22:in `block (3 levels) in <module:Channels>'.

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /home/ares/aresmush/spec/spec_helper.rb:39:in `setup_mock_client'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total
```

This commit updates the code while allowing all tests to continue passing.