### PR TITLE
Fix minor typo. roles.doesnt_has_role -> roles.doesnt_have_role

### DIFF
--- a/plugins/roles/public/roles_api.rb
+++ b/plugins/roles/public/roles_api.rb
@@ -22,7 +22,7 @@ module AresMUSH
       end
       
       if (!char.has_role?(role_name))
-        return t('roles.doesnt_has_role', :name => char.name)
+        return t('roles.doesnt_have_role', :name => char.name)
       end
     
       char.roles.delete role

--- a/plugins/rooms/commands/build_cmd.rb
+++ b/plugins/rooms/commands/build_cmd.rb
@@ -27,7 +27,7 @@ module AresMUSH
       end
       
       def handle
-        room = AresMUSH::Room.create(:name => name, :room_area => enactor_room.room_area)
+        room = AresMUSH::Room.create(:name => name, :area => enactor.room.area)
         client.emit_success(t('rooms.room_created', :name => name))
         
         if (!self.exit.empty?)


### PR DESCRIPTION
Noticed this while I was fiddling with the code that does some things automatically upon approving someone.

```
%% translation missing: en.roles.doesnt_has_role
```