### PR TITLE
Add config option for patient to healing skill ratio

### DIFF
--- a/plugins/fs3combat/helpers/damage_helper.rb
+++ b/plugins/fs3combat/helpers/damage_helper.rb
@@ -90,7 +90,12 @@ module AresMUSH
      
      def self.max_patients(char)
        rating = FS3Skills.ability_rating(char, FS3Combat.healing_skill)
-       rating / 2
+       patient_to_heal_skill_ratio = Global.read_config("fs3combat", "healing_skill_patient_ratio")
+       Global.logger.info("patient_to_heal_skill_ratio #{patient_to_heal_skill_ratio}")
+       if patient_to_heal_skill_ratio.nil? || patient_to_heal_skill_ratio <= 0
+         patient_to_heal_skill_ratio = 0.5
+       end
+       (rating * patient_to_heal_skill_ratio).round()
      end
      
      def self.heal_wounds(char)


### PR DESCRIPTION
This allows admins to tune the patients quota per healing skill ratio. This retains the default of 1:2.

This was a simple solution to ease problems with player activity and reliability for our combat healers vs our out of combat healers when facing a much larger PC patient population.