### PR TITLE
Added British English spellings of 'color' and 'armor' to commands.

### DIFF
--- a/plugins/channels/channels.rb
+++ b/plugins/channels/channels.rb
@@ -23,7 +23,7 @@ module AresMUSH
           return ChannelAnnounceCmd
         when "clear"
           return ChannelClearCmd
-        when "color"
+        when "color", "colour"
           return ChannelColorCmd
         when "create"
           return ChannelCreateCmd

--- a/plugins/fs3combat/fs3combat.rb
+++ b/plugins/fs3combat/fs3combat.rb
@@ -74,7 +74,7 @@ module AresMUSH
            return CombatAmmoCmd
          when "attackmod", "defensemod", "lethalmod", "initmod"
            return CombatModCmd
-         when "armor"
+         when "armor", "armour"
            return CombatArmorCmd
          when "hitloc"
            return CombatHitlocsCmd

--- a/plugins/fs3combat/fs3combat.rb
+++ b/plugins/fs3combat/fs3combat.rb
@@ -29,7 +29,7 @@ module AresMUSH
          end
        when "treat"
          return TreatCmd
-       when "armor"
+       when "armor", "armour"
          if (cmd.args)
            return ArmorDetailCmd
          else

--- a/plugins/fs3combat/web/gear_detail_request_handler.rb
+++ b/plugins/fs3combat/web/gear_detail_request_handler.rb
@@ -12,7 +12,7 @@ module AresMUSH
         case (type || "").downcase
         when "weapon"
           data = FS3Combat.weapon(name)
-        when "armor"
+        when "armor", "armour"
           data = FS3Combat.armor(name)
         when "vehicle"
           data = FS3Combat.vehicle(name)
@@ -47,5 +47,3 @@ module AresMUSH
     end
   end
 end
-
-

--- a/plugins/page/page.rb
+++ b/plugins/page/page.rb
@@ -16,7 +16,7 @@ module AresMUSH
         case cmd.switch
         when "autospace"
           return PageAutospaceCmd
-        when "color"
+        when "color", "colour"
           return PageColorCmd
         when "dnd"
           return PageDoNotDisturbCmd

--- a/plugins/utils/utils.rb
+++ b/plugins/utils/utils.rb
@@ -18,7 +18,7 @@ module AresMUSH
         return AsciiCmd
       when "beep"
         return BeepCmd
-      when "color"
+      when "color", "colour"
         if (cmd.args)
           return ColorModeCmd
         else


### PR DESCRIPTION
This will make things just a little easier for our friends across the pond. `combat/armour` now works, as well as the `colour` command etc.