### PR TITLE
BorderedTableTemplate now respects color codes for column width

### DIFF
--- a/plugins/globals/templates/bordered_table_template.rb
+++ b/plugins/globals/templates/bordered_table_template.rb
@@ -21,7 +21,7 @@ module AresMUSH
           @lines << current_line
           current_line = ""
         end
-        current_line << i.truncate(column_width - 1).ljust(column_width)
+        current_line << left(i.truncate(column_width - 1), column_width)
         count = count + 1
       end
       


### PR DESCRIPTION
moved to `left()` from `ljust()`